### PR TITLE
fix: `no-spaced-func` was deprecated in v3.3.0

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -106,7 +106,6 @@ module.exports = {
       'LabeledStatement',
       'WithStatement',
     ],
-    'no-spaced-func': 'error',
     'object-curly-spacing': ['error', 'always'],
     'no-return-await': 'off',
     'space-before-function-paren': ['error', 'never'],


### PR DESCRIPTION
Hi, I am studying eslint rules recently and found that the `no-spaced-func` in the project has been deprecated in `eslint v3.3.0`, but the `eslint` version in `peerDependencies` is `>=7.4.0`, so I think this rule can be deleted.

[more to see](https://eslint.org/docs/rules/no-spaced-func#disallow-spacing-between-function-identifiers-and-their-applications-no-spaced-func)