### PR TITLE
refactor: simplify eslint-plugin-import extend

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -6,8 +6,7 @@ module.exports = {
   },
   extends: [
     'standard',
-    'plugin:import/errors',
-    'plugin:import/warnings',
+    'plugin:import/recommended',
     'plugin:eslint-comments/recommended',
     'plugin:jsonc/recommended-with-jsonc',
     'plugin:yml/standard',


### PR DESCRIPTION
I see that. Maybe we just need `plugin:import/recommended`.

```yaml
extends:
  - eslint:recommended
  - plugin:import/recommended
  # alternatively, 'recommended' is the combination of these two rule sets:
  - plugin:import/errors
  - plugin:import/warnings
```

> https://github.com/benmosher/eslint-plugin-import#installation