### PR TITLE
fix: `eqeqeq` rule deprecated option allow-null

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -145,7 +145,7 @@ module.exports = {
     'block-scoped-var': 'error',
     'consistent-return': 'off',
     'complexity': ['off', 11],
-    'eqeqeq': ['error', 'always', { null: 'ignore' }],
+    'eqeqeq': ['error', 'smart'],
     'no-alert': 'warn',
     'no-case-declarations': 'error',
     'no-multi-spaces': 'error',

--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -145,7 +145,7 @@ module.exports = {
     'block-scoped-var': 'error',
     'consistent-return': 'off',
     'complexity': ['off', 11],
-    'eqeqeq': ['error', 'allow-null'],
+    'eqeqeq': ['error', 'always', { null: 'ignore' }],
     'no-alert': 'warn',
     'no-case-declarations': 'error',
     'no-multi-spaces': 'error',


### PR DESCRIPTION
According to the [`eqeqeq` rule docs](https://eslint.org/docs/rules/eqeqeq#allow-null) - option `allow-null` is deprecated.

https://eslint.org/docs/rules/eqeqeq#allow-null

> Deprecated: Instead of using this option use "always" and pass a "null" option property with value "ignore". This will tell ESLint to always enforce strict equality except when comparing with the null literal.

This PR fixes it to use the null option.

**NOTICE**: If you prefer, `eqeqeq` has also [`smart` option](https://eslint.org/docs/rules/eqeqeq#smart) instead of `always` but it behaves differently.

