### PR TITLE
feat: use yaml-eslint-parser

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -31,6 +31,10 @@ module.exports = {
       },
     },
     {
+      files: ["*.yaml", "*.yml"],
+      parser: "yaml-eslint-parser",
+    },
+    {
       files: ['package.json'],
       parser: 'jsonc-eslint-parser',
       rules: {


### PR DESCRIPTION
Hey Anthony! I have noticed we have yaml-eslint-parser as a dependency but it is not used. What do you think of this change?