### PR TITLE
fix: eslint-plugin-import support TypeScript

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -35,7 +35,7 @@ module.exports = {
   ],
   settings: {
     'import/resolver': {
-      node: { extensions: ['.js', '.mjs', '.ts', '.d.ts'] },
+      node: { extensions: ['.js', '.mjs'] },
     },
   },
   overrides: [

--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -4,8 +4,14 @@ const basic = require('@antfu/eslint-config-basic')
 module.exports = {
   extends: [
     '@antfu/eslint-config-basic',
+    'plugin:import/typescript',
     'plugin:@typescript-eslint/recommended',
   ],
+  settings: {
+    'import/resolver': {
+      node: { extensions: ['.js', '.jsx', '.mjs', '.ts', '.tsx', '.d.ts'] },
+    },
+  },
   overrides: basic.overrides,
   rules: {
     'import/named': 'off',


### PR DESCRIPTION
`eslint-plugin-import` does not support TypeScript by default , and `plugin:import/typescript` configuration needs to be added.

reference：

- [eslint-plugin-import support TypeScript](https://github.com/import-js/eslint-plugin-import#typescript)
- [useful stuff for folks using various environments](https://github.com/import-js/eslint-plugin-import/blob/main/src/index.js#L68)
