### PR TITLE
fix: space-before-function-paren allows space in anonymous and asyncArrow function.

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -183,7 +183,14 @@ module.exports = {
     ],
     'object-curly-spacing': ['error', 'always'],
     'no-return-await': 'off',
-    'space-before-function-paren': ['error', 'never'],
+    'space-before-function-paren': [
+      'error',
+      {
+        'anonymous': 'always',
+        'named': 'never',
+        'asyncArrow': 'always'
+      }
+    ],
     'no-multiple-empty-lines': ['error', { max: 1, maxBOF: 0, maxEOF: 1 }],
 
     // es6

--- a/packages/basic/standard.js
+++ b/packages/basic/standard.js
@@ -202,7 +202,14 @@ module.exports = {
     'semi': ['error', 'never'],
     'semi-spacing': ['error', { before: false, after: true }],
     'space-before-blocks': ['error', 'always'],
-    'space-before-function-paren': ['error', 'always'],
+    'space-before-function-paren': [
+      'error',
+      {
+        'anonymous': 'always',
+        'named': 'never',
+        'asyncArrow': 'always'
+      }
+    ],
     'space-in-parens': ['error', 'never'],
     'space-infix-ops': 'error',
     'space-unary-ops': ['error', { words: true, nonwords: false }],


### PR DESCRIPTION
related issue: [83](https://github.com/antfu/eslint-config/issues/83)
solution: [eslint docs](https://eslint.org/docs/rules/space-before-function-paren#anonymous-always-named-never-asyncarrow-always)