### PR TITLE
fix: complete typescript overrides

### DIFF
--- a/packages/basic/standard.js
+++ b/packages/basic/standard.js
@@ -205,10 +205,10 @@ module.exports = {
     'space-before-function-paren': [
       'error',
       {
-        'anonymous': 'always',
-        'named': 'never',
-        'asyncArrow': 'always'
-      }
+        anonymous: 'always',
+        named: 'never',
+        asyncArrow: 'always',
+      },
     ],
     'space-in-parens': ['error', 'never'],
     'space-infix-ops': 'error',

--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -104,8 +104,8 @@ module.exports = {
     '@typescript-eslint/no-loss-of-precision': 'error',
     'lines-between-class-members': 'off',
     '@typescript-eslint/lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
-    // The following rule overrides requires a parser service, aka. requires a `typescript.json` path.
-    // This needs to be done individually for each project, and slows down linting significantly.
+    // The following rule overrides require a parser service, aka. require a `typescript.json` path.
+    // This needs to be done individually for each project, and it slows down linting significantly.
     // 'no-throw-literal': 'off',
     // '@typescript-eslint/no-throw-literal': 'error',
     // 'no-implied-eval': 'off',

--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -17,7 +17,6 @@ module.exports = {
     'import/named': 'off',
 
     // TS
-    '@typescript-eslint/semi': ['error', 'never'],
     '@typescript-eslint/ban-ts-comment': ['error', { 'ts-ignore': 'allow-with-description' }],
     '@typescript-eslint/member-delimiter-style': ['error', { multiline: { delimiter: 'none' } }],
     '@typescript-eslint/type-annotation-spacing': ['error', {}],
@@ -76,6 +75,43 @@ module.exports = {
     '@typescript-eslint/comma-dangle': ['error', 'always-multiline'],
     'object-curly-spacing': 'off',
     '@typescript-eslint/object-curly-spacing': ['error', 'always'],
+    'semi': 'off',
+    '@typescript-eslint/semi': ['error', 'never'],
+    'quotes': 'off',
+    '@typescript-eslint/quotes': ['error', 'single'],
+    'space-before-blocks': 'off',
+    '@typescript-eslint/space-before-blocks': ['error', 'always'],
+    'space-before-function-paren': 'off',
+    '@typescript-eslint/space-before-function-paren': [
+      'error',
+      {
+        anonymous: 'always',
+        named: 'never',
+        asyncArrow: 'always',
+      },
+    ],
+    'space-infix-ops': 'off',
+    '@typescript-eslint/space-infix-ops': 'error',
+    'keyword-spacing': 'off',
+    '@typescript-eslint/keyword-spacing': ['error', { before: true, after: true }],
+    'comma-spacing': 'off',
+    '@typescript-eslint/comma-spacing': ['error', { before: false, after: true }],
+    'no-extra-parens': 'off',
+    '@typescript-eslint/no-extra-parens': ['error', 'functions'],
+    'no-dupe-class-members': 'off',
+    '@typescript-eslint/no-dupe-class-members': 'error',
+    'no-loss-of-precision': 'off',
+    '@typescript-eslint/no-loss-of-precision': 'error',
+    'lines-between-class-members': 'off',
+    '@typescript-eslint/lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+    // The following rule overrides requires a parser service, aka. requires a `typescript.json` path.
+    // This needs to be done individually for each project, and slows down linting significantly.
+    // 'no-throw-literal': 'off',
+    // '@typescript-eslint/no-throw-literal': 'error',
+    // 'no-implied-eval': 'off',
+    // '@typescript-eslint/no-implied-eval': 'error',
+    // 'dot-notation': 'off',
+    // '@typescript-eslint/dot-notation': ['error', { allowKeywords: true }],
 
     // off
     '@typescript-eslint/camelcase': 'off',


### PR DESCRIPTION
I noticed the typescript overrides are not complete, eg. `space-infix-ops` is not present so it doesn't work on unions.
So I spent some time iterated through the docs and added overrides for all that `typescript-eslint` recommended to.
I haven't tested it, but it should work.