### PR TITLE
fix: remove deprecated rules

### DIFF
--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -114,11 +114,11 @@ module.exports = {
     // '@typescript-eslint/dot-notation': ['error', { allowKeywords: true }],
 
     // off
-    '@typescript-eslint/camelcase': 'off',
+    '@typescript-eslint/naming-convention': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-parameter-properties': 'off',
+    '@typescript-eslint/parameter-properties': 'off',
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/ban-ts-ignore': 'off',
     '@typescript-eslint/no-empty-function': 'off',


### PR DESCRIPTION
[no-parameter-properties](https://github.com/typescript-eslint/typescript-eslint/blob/88ed9ec9d6b971a9533565920fdcd6890ea941e9/packages/eslint-plugin/src/rules/no-parameter-properties.ts#L23)
[camelcase](https://typescript-eslint.io/rules/camelcase)