### PR TITLE
fix: add missing extension rules

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -44,9 +44,15 @@ module.exports = {
       files: ['*.json', '*.json5'],
       parser: 'jsonc-eslint-parser',
       rules: {
-        'jsonc/quotes': ['error', 'double'],
-        'jsonc/quote-props': ['error', 'always'],
+        'jsonc/array-bracket-spacing': ['error', 'never'],
         'jsonc/comma-dangle': ['error', 'never'],
+        'jsonc/comma-style': ['error', 'last'],
+        'jsonc/indent': ['error', 2],
+        'jsonc/key-spacing': ['error', { beforeColon: false, afterColon: true }],
+        'jsonc/no-octal-escape': 'error',
+        'jsonc/object-curly-newline': ['error', { multiline: true, consistent: true }],
+        'jsonc/object-curly-spacing': ['error', 'always'],
+        'jsonc/object-property-newline': ['error', { allowMultiplePropertiesPerLine: true }],
       },
     },
     {


### PR DESCRIPTION
https://ota-meshi.github.io/eslint-plugin-jsonc/rules/#extension-rules