### PR TITLE
fix: rule renamed

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -265,7 +265,7 @@ module.exports = {
     // Uppercase regex escapes
     'unicorn/escape-case': 'error',
     // Array.isArray instead of instanceof
-    'unicorn/no-array-instanceof': 'error',
+    'unicorn/no-instanceof-array': 'error',
     // Prevent deprecated `new Buffer()`
     'unicorn/no-new-buffer': 'error',
     // Keep regex literals safe!


### PR DESCRIPTION
`no-array-instanceof` was renamed to `no-instanceof-array` [deprecated-rules](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/deprecated-rules.md#no-array-instanceof)