### PR TITLE
fix: prioritize require

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -124,8 +124,8 @@ module.exports = {
             pathPattern: '^exports.*$',
             order: [
               'types',
-              'import',
               'require',
+              'import',
             ],
           },
         ],


### PR DESCRIPTION
`jiti` (`mlly`) will load exports by the order in `package.json`. Since `jiti` needs to transpile ESM files, it's generally better to make CJS export prioritized.