### PR TITLE
fix: rule renamed

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -300,7 +300,7 @@ module.exports = {
     // includes over indexOf when checking for existence
     'unicorn/prefer-includes': 'error',
     // String methods startsWith/endsWith instead of more complicated stuff
-    'unicorn/prefer-starts-ends-with': 'error',
+    'unicorn/prefer-string-starts-ends-with': 'error',
     // textContent instead of innerText
     'unicorn/prefer-text-content': 'error',
     // Enforce throwing type error when throwing error while checking typeof


### PR DESCRIPTION
unicorn/prefer-starts-ends-with was renamed since 25.0 [deprecated-rules](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/deprecated-rules.md#prefer-starts-ends-with)
