### PR TITLE
feat: remove `@typescript-eslint/consistent-type-imports`

### DIFF
--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -19,7 +19,6 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': ['error', { 'ts-ignore': 'allow-with-description' }],
     '@typescript-eslint/member-delimiter-style': ['error', { multiline: { delimiter: 'none' } }],
     '@typescript-eslint/type-annotation-spacing': ['error', {}],
-    '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports', disallowTypeAnnotations: false }],
     '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
     '@typescript-eslint/prefer-ts-expect-error': 'error',
 


### PR DESCRIPTION
Remove `@typescript-eslint/consistent-type-imports` to improve compatibility for Angular and Nest.

In Ioc framework, code below are commonly used by developer.

```ts
import { AClass } from './a-class'

@Injectable()
export class BClass {
  constructor(private readonly aClass: AClass){}
}
```

After  formatting,  code `import { AClass } from './a-class'` will become `import type { AClass } from './a-class'`, which will  cause error, because typescript complier cannot get metadata by reflection.
