### PR TITLE
fix: add `*.thrift` to ignorePatterns

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -14,6 +14,7 @@ module.exports = {
     'plugin:markdown/recommended',
   ],
   ignorePatterns: [
+    '*.thrift',
     '*.min.*',
     '*.d.ts',
     'CHANGELOG.md',


### PR DESCRIPTION
Let's say developer using lint-staged to lint the code before git commit. And the `.lintstagedrc` file looks like this:
```json
{"*": "eslint --fix"}
```
It will cause error if developer is going to commit thrift file.

If not accept this PR:
1. create a standard thrift file `xxx.thrift`
2. npx eslint xxx.thrift
3. it will throw an error on the console.

After accept this PR:
1. create a standard thrift file `xxx.thrift`
2. npx eslint xxx.thrift
3. print a warn `warning  File ignored because of a matching ignore pattern. Use "--no-ignore" to override` on the console

