### PR TITLE
fix(basic): disallow multi empty lines at the end of file

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -223,7 +223,7 @@ module.exports = {
         asyncArrow: 'always',
       },
     ],
-    'no-multiple-empty-lines': ['error', { max: 1, maxBOF: 0, maxEOF: 1 }],
+    'no-multiple-empty-lines': ['error', { max: 1, maxBOF: 0, maxEOF: 0 }],
 
     // es6
     'no-var': 'error',


### PR DESCRIPTION
```js
require('eslint')
// empty line
// empty line
```
Files that have multi empty lines at the end should throw error when linting.
But it doesn't work actually.
This PR Fix this problem.
See https://github.com/eslint/eslint/issues/12742#issuecomment-570904439