### PR TITLE
feat(basic): disable `consistent-type-imports` in markdown file

### DIFF
--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -168,6 +168,7 @@ module.exports = {
         '@typescript-eslint/no-use-before-define': 'off',
         '@typescript-eslint/no-var-requires': 'off',
         '@typescript-eslint/comma-dangle': 'off',
+        '@typescript-eslint/consistent-type-imports': 'off',
         'import/no-unresolved': 'off',
         'no-alert': 'off',
         'no-console': 'off',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Thanks to this PR #131, I've solved the problem of #110. See https://github.com/antfu/eslint-config/pull/110#issuecomment-1343853431.

Although I've solved the problem after adding a `tsconfig.eslint.json` file to project root, markdown files still have strict limitation, because ts scripts in markdown file cannot works very well with type-aware linting. 

Therefore, I hope we can turn off `@typescript-eslint/consistent-type-imports` in markdown file, which help ioc project a lot.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
