### PR TITLE
feat(ts): enable `jest/unbound-method`

### DIFF
--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -51,6 +51,15 @@ module.exports = {
             '@typescript-eslint/restrict-template-expressions': 'error',
             '@typescript-eslint/unbound-method': 'error',
           },
+        }, {
+          // https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md
+          files: ['**/__tests__/**/*.ts', '**/*.spec.ts', '**/*.test.ts'],
+          plugins: ['jest'],
+          rules: {
+            // you should turn the original rule off *only* for test files
+            '@typescript-eslint/unbound-method': 'off',
+            'jest/unbound-method': 'error',
+          },
         }],
   ),
   rules: {

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@antfu/eslint-config-basic": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^5.46.0",
-    "@typescript-eslint/parser": "^5.46.0"
+    "@typescript-eslint/parser": "^5.46.0",
+    "eslint-plugin-jest": "^27.1.6"
   },
   "devDependencies": {
     "eslint": "^8.29.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,10 +122,12 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.46.0
       '@typescript-eslint/parser': ^5.46.0
       eslint: ^8.29.0
+      eslint-plugin-jest: ^27.1.6
     dependencies:
       '@antfu/eslint-config-basic': link:../basic
       '@typescript-eslint/eslint-plugin': 5.46.0_jx43xxcguvnqqmtmaaygwl7cmu
       '@typescript-eslint/parser': 5.46.0_eslint@8.29.0
+      eslint-plugin-jest: 27.1.6_az5lmaeuvswqhyu3aute3pgqim
     devDependencies:
       eslint: 8.29.0
 
@@ -1847,6 +1849,27 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: false
+
+  /eslint-plugin-jest/27.1.6_az5lmaeuvswqhyu3aute3pgqim:
+    resolution: {integrity: sha512-XA7RFLSrlQF9IGtAmhddkUkBuICCTuryfOTfCSWcZHiHb69OilIH05oozH2XA6CEOtztnOd0vgXyvxZodkxGjg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.0.0
+      eslint: ^7.0.0 || ^8.0.0
+      jest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      jest:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.46.0_jx43xxcguvnqqmtmaaygwl7cmu
+      '@typescript-eslint/utils': 5.46.0_eslint@8.29.0
+      eslint: 8.29.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: false
 
   /eslint-plugin-jsonc/2.5.0_eslint@8.29.0:


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hi. Enabling `@typescript-eslint/unbound-method` will make some trouble when using `jest` or `vitest`. This PR will convenient for writing unit test.

See https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
