### PR TITLE
fix: allow void as statement in ts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Install [VS Code ESLint extension](https://marketplace.visualstudio.com/items?it
 
 ### TypeScript Aware Rules
 
-Type aware rules are enabled when a `tsconfig.eslint.json` is found in the project root. If you want to enable it while have no `tsconfig.eslint.json` in the project root, you can change tsconfig name by modifying `ESLINT_TSCONFIG` env. 
+Type aware rules are enabled when a `tsconfig.eslint.json` is found in the project root, which will introduce some stricter rules into your project. If you want to enable it while have no `tsconfig.eslint.json` in the project root, you can change tsconfig name by modifying `ESLINT_TSCONFIG` env. 
 
 ```js
 // .eslintrc.js

--- a/packages/basic/index.js
+++ b/packages/basic/index.js
@@ -148,6 +148,12 @@ module.exports = {
       },
     },
     {
+      files: ['*.ts', '*.tsx', '*.mts', '*.cts'],
+      rules: {
+        'no-void': ['error', { allowAsStatement: true }],
+      },
+    },
+    {
       files: ['scripts/**/*.*', 'cli.*'],
       rules: {
         'no-console': 'off',

--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -34,7 +34,6 @@ module.exports = {
             '@typescript-eslint/no-implied-eval': 'error',
             'dot-notation': 'off',
             '@typescript-eslint/dot-notation': ['error', { allowKeywords: true }],
-            'no-void': ['error', { allowAsStatement: true }],
             '@typescript-eslint/no-floating-promises': 'error',
             '@typescript-eslint/no-misused-promises': 'error',
             '@typescript-eslint/await-thenable': 'error',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

```ts
// main.ts
/* eslint-disable @typescript-eslint/require-await */
async function test() {
  return 'test'
}

setTimeout(() => {
  void test()
})

export {}
```
Let's say I have code above. Run lint will cause `no-void` error. But after adding `tsconfig.eslint.json` file to project root, this error will disappear. 

I think, adding `tsconfig.eslint.json` file to the root of project should bring more stricter rules to project. Deleting the `tsconfig.eslint.json` file should remove some stricter rules. But in the example above, deleting the `tsconfig.eslint.json` file will bring more stricter rule, which should not be.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
