### PR TITLE
feat(ts): support DI project out-of-box

### DIFF
--- a/packages/eslint-config-ts/index.js
+++ b/packages/eslint-config-ts/index.js
@@ -49,6 +49,7 @@ module.exports = {
             '@typescript-eslint/restrict-plus-operands': 'error',
             '@typescript-eslint/restrict-template-expressions': 'error',
             '@typescript-eslint/unbound-method': 'error',
+            '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports' }],
           },
         }, {
           // https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md
@@ -68,7 +69,6 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': ['error', { 'ts-ignore': 'allow-with-description' }],
     '@typescript-eslint/member-delimiter-style': ['error', { multiline: { delimiter: 'none' } }],
     '@typescript-eslint/type-annotation-spacing': ['error', {}],
-    '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports', disallowTypeAnnotations: false }],
     '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
     '@typescript-eslint/prefer-ts-expect-error': 'error',
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hey @antfu.

Dependency-injection projects, like [InversifyJS](https://github.com/inversify/InversifyJS) or angular, will introduce BUG if they use this project to format code. Is there any possible to support them out-of-box?

```ts
import AClass from './a-class' // Should not be formatted into `import type AClass from './a-class'` in DI project

@Injectable()
class B {
  constructor(a: AClass){}
}
```



### Linked Issues


### Additional context
https://typescript-eslint.io/rules/consistent-type-imports/#usage-with-emitdecoratormetadata

