### PR TITLE
feat: improve compatibility with `noPropertyAccessFromIndexSignature`

### DIFF
--- a/packages/eslint-config-basic/index.js
+++ b/packages/eslint-config-basic/index.js
@@ -163,6 +163,7 @@ module.exports = {
       files: ['*.ts', '*.tsx', '*.mts', '*.cts'],
       rules: {
         'no-void': ['error', { allowAsStatement: true }],
+        'dot-notation': 'off',
       },
     },
     {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Ts project, which enabled [noPropertyAccessFromIndexSignature](https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature), will have conflict with `dot-notation`. 

[Line 36](https://github.com/antfu/eslint-config/blob/main/packages/typescript/index.js#L36) has enabled `@typescript-eslint/dot-notation`. So, we can disable `dot-notation` in ts file. People who want to enable `dot-notation` can enable type aware rules by adding `tsconfig.eslint.json` file.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
