### PR TITLE
fix: group `&&`, `||` and `?:`

### DIFF
--- a/packages/basic/standard.js
+++ b/packages/basic/standard.js
@@ -126,7 +126,7 @@ module.exports = {
     'no-mixed-operators': ['error', {
       groups: [
         ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
-        ['&&', '||'],
+        ['&&', '||', '?:'],
         ['in', 'instanceof'],
       ],
       allowSamePrecedence: true,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Using both `&&`, `||` and `?:` makes it hard to figure out their precedence without group

### Linked Issues

Ref https://github.com/antfu/sponsorkit/pull/36

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
