### PR TITLE
feat(ts): ban cjs exports in ts file

### DIFF
--- a/packages/eslint-config-ts/index.js
+++ b/packages/eslint-config-ts/index.js
@@ -158,6 +158,8 @@ module.exports = {
 
     // antfu
     'antfu/generic-spacing': 'error',
+    'antfu/no-cjs-exports': 'error',
+    'antfu/no-ts-export-equal': 'error',
 
     // off
     '@typescript-eslint/consistent-indexed-object-style': 'off',

--- a/packages/eslint-plugin-antfu/src/index.ts
+++ b/packages/eslint-plugin-antfu/src/index.ts
@@ -3,6 +3,8 @@ import ifNewline from './rules/if-newline'
 import importDedupe from './rules/import-dedupe'
 import preferInlineTypeImport from './rules/prefer-inline-type-import'
 import topLevelFunction from './rules/top-level-function'
+import noTsExportEqual from './rules/no-ts-export-equal'
+import noCjsExports from './rules/no-cjs-exports'
 
 export default {
   rules: {
@@ -11,5 +13,7 @@ export default {
     'prefer-inline-type-import': preferInlineTypeImport,
     'generic-spacing': genericSpacing,
     'top-level-function': topLevelFunction,
+    'no-cjs-exports': noCjsExports,
+    'no-ts-export-equal': noTsExportEqual,
   },
 }

--- a/packages/eslint-plugin-antfu/src/rules/no-cjs-exports.test.ts
+++ b/packages/eslint-plugin-antfu/src/rules/no-cjs-exports.test.ts
@@ -1,0 +1,28 @@
+import { RuleTester } from '@typescript-eslint/utils/dist/ts-eslint'
+import { it } from 'vitest'
+import rule, { RULE_NAME } from './no-cjs-exports'
+
+const valids = [
+  { code: 'export = {}', filename: 'test.ts' },
+  { code: 'exports.a = {}', filename: 'test.js' },
+  { code: 'module.exports.a = {}', filename: 'test.js' },
+]
+
+const invalids = [
+  { code: 'exports.a = {}', filename: 'test.ts' },
+  { code: 'module.exports.a = {}', filename: 'test.ts' },
+]
+
+it('runs', () => {
+  const ruleTester: RuleTester = new RuleTester({
+    parser: require.resolve('@typescript-eslint/parser'),
+  })
+
+  ruleTester.run(RULE_NAME, rule, {
+    valid: valids,
+    invalid: invalids.map(i => ({
+      ...i,
+      errors: [{ messageId: 'noCjsExports' }],
+    })),
+  })
+})

--- a/packages/eslint-plugin-antfu/src/rules/no-cjs-exports.ts
+++ b/packages/eslint-plugin-antfu/src/rules/no-cjs-exports.ts
@@ -1,0 +1,41 @@
+import { createEslintRule } from '../utils'
+
+export const RULE_NAME = 'no-cjs-exports'
+export type MessageIds = 'noCjsExports'
+export type Options = []
+
+export default createEslintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Do not use CJS exports',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      noCjsExports: 'Use ESM export instead',
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    const extension = context.getFilename().split('.').pop()
+    if (!['ts', 'tsx', 'mts', 'cts'].includes(extension))
+      return {}
+
+    return {
+      'MemberExpression[object.name="exports"]': function (node) {
+        context.report({
+          node,
+          messageId: 'noCjsExports',
+        })
+      },
+      'MemberExpression[object.name="module"][property.name="exports"]': function (node) {
+        context.report({
+          node,
+          messageId: 'noCjsExports',
+        })
+      },
+    }
+  },
+})

--- a/packages/eslint-plugin-antfu/src/rules/no-ts-export-equal.test.ts
+++ b/packages/eslint-plugin-antfu/src/rules/no-ts-export-equal.test.ts
@@ -1,0 +1,26 @@
+import { RuleTester } from '@typescript-eslint/utils/dist/ts-eslint'
+import { it } from 'vitest'
+import rule, { RULE_NAME } from './no-ts-export-equal'
+
+const valids = [
+  { code: 'export default {}', filename: 'test.ts' },
+  { code: 'export = {}', filename: 'test.js' },
+]
+
+const invalids = [
+  { code: 'export = {}', filename: 'test.ts' },
+]
+
+it('runs', () => {
+  const ruleTester: RuleTester = new RuleTester({
+    parser: require.resolve('@typescript-eslint/parser'),
+  })
+
+  ruleTester.run(RULE_NAME, rule, {
+    valid: valids,
+    invalid: invalids.map(i => ({
+      ...i,
+      errors: [{ messageId: 'noTsExportEqual' }],
+    })),
+  })
+})

--- a/packages/eslint-plugin-antfu/src/rules/no-ts-export-equal.ts
+++ b/packages/eslint-plugin-antfu/src/rules/no-ts-export-equal.ts
@@ -1,0 +1,35 @@
+import { createEslintRule } from '../utils'
+
+export const RULE_NAME = 'no-ts-export-equal'
+export type MessageIds = 'noTsExportEqual'
+export type Options = []
+
+export default createEslintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Do not use `exports =`',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      noTsExportEqual: 'Use ESM `export default` instead',
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    const extension = context.getFilename().split('.').pop()
+    if (!['ts', 'tsx', 'mts', 'cts'].includes(extension))
+      return {}
+
+    return {
+      TSExportAssignment(node) {
+        context.report({
+          node,
+          messageId: 'noTsExportEqual',
+        })
+      },
+    }
+  },
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Ban cjs exports in ts file.

```ts
if (true)
  module.exports = {}

module.exports = {}

if (true)
  exports.a = 1

exports.a = 1

function f() {
  exports.a = 1
}

const a = {
  exports: {
    tmp: 'hi',
  },
}

a.exports.tmp = 'hello'

export = 'abc'

export default 'hello'

export const tmp = 'world'

```

Copy this content to test.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
