### PR TITLE
fix: temporarily remove `considerComments` to mitigate problem with upstream module

### DIFF
--- a/packages/eslint-config-basic/index.js
+++ b/packages/eslint-config-basic/index.js
@@ -210,7 +210,7 @@ module.exports = {
     'import/no-mutable-exports': 'error',
     'import/no-unresolved': 'off',
     'import/no-absolute-path': 'off',
-    'import/newline-after-import': ['error', { count: 1, considerComments: true }],
+    'import/newline-after-import': ['error', { count: 1 }],
 
     // Common
     'semi': ['error', 'never'],


### PR DESCRIPTION
This fixes #175

Currently, `antfu/eslint-config` stops eslint from running at all on the latest version, so this fixes it for now