### PR TITLE
feat(basic): ban `global` variable

### DIFF
--- a/packages/eslint-config-basic/index.js
+++ b/packages/eslint-config-basic/index.js
@@ -259,6 +259,7 @@ module.exports = {
         asyncArrow: 'always',
       },
     ],
+    'no-restricted-globals': ['error', { name: 'global', message: 'Use `globalThis` instead.' }],
 
     // es6
     'no-var': 'error',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Although we can use `global` object in Node environment, it is not a standard object. `globalThis` is the standard which can be used in browser and Deno.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
