### PR TITLE
fix: package.json export map proper order

### DIFF
--- a/packages/eslint-config-basic/index.js
+++ b/packages/eslint-config-basic/index.js
@@ -141,9 +141,10 @@ module.exports = {
           {
             pathPattern: '^exports.*$',
             order: [
-              'types',
               'require',
               'import',
+              'types',
+              'default',
             ],
           },
         ],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

types should come after require and import to not override the map.

There's something wrong with https://publint.dev/rules#exports_types_should_be_first, the "correct" way to have an export map that works without errors is to do this :

```
  "exports": {
    ".": {
      "require": {
        "types": "./dist/module.d.cts",
        "default": "./dist/module.cjs"
      },
      "import": {
        "types": "./dist/module.d.mts",
        "default": "./dist/module.mjs"
      },
      "types": "./dist/module.d.ts",
      "default": "./dist/module.mjs"
    },
    "./*": "./*"
  },
  "main": "./dist/module.cjs",
  "module": "./dist/module.mjs",
  "types": "./dist/types.d.ts",
  "files": [
    "dist",
    "*.d.ts",
    "*.cjs",
    "*.mjs"
  ],
  ``` 
  This gives all green for packages that emits both cjs and esm files => https://arethetypeswrong.github.io/ 
  
  See [example of a working map](https://arethetypeswrong.github.io/?p=%40hebilicious%2Fform-actions-nuxt%400.0.8).


### Linked Issues

https://github.com/bluwy/publint/issues/46

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This is not very concerning as it's easy to override on my side, but I think it's an improvement. Feel free to close if you don't like it.