### PR TITLE
docs: update `organizeImports` config for VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,15 @@ Install [VS Code ESLint extension](https://marketplace.visualstudio.com/items?it
   "prettier.enable": false,
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": true,
+    "source.organizeImports": false
   }
 }
 ```
 
 ### TypeScript Aware Rules
 
-Type aware rules are enabled when a `tsconfig.eslint.json` is found in the project root, which will introduce some stricter rules into your project. If you want to enable it while have no `tsconfig.eslint.json` in the project root, you can change tsconfig name by modifying `ESLINT_TSCONFIG` env. 
+Type aware rules are enabled when a `tsconfig.eslint.json` is found in the project root, which will introduce some stricter rules into your project. If you want to enable it while have no `tsconfig.eslint.json` in the project root, you can change tsconfig name by modifying `ESLINT_TSCONFIG` env.
 
 ```js
 // .eslintrc.js


### PR DESCRIPTION
### Description
With the default configuration for VSCode, there is a race condition when saving a file with ordering imports. 
This happens because there is an `import/order` rule configured.

With the following settings it respects the linter and will work as expected:

```diff
# settings.json

"editor.codeActionsOnSave": {
    "source.fixAll.eslint": true,
+   "source.organizeImports": false
}
```