### PR TITLE
docs: add `eslint.validate` to enable linting for supported filetypes with VSCode ESLint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,14 @@ For example:
 }
 ```
 
-### Config VS Code auto fix
+### VS Code support (auto fix)
 
-Install [VS Code ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) and create `.vscode/settings.json`
+- Install [VS Code ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+
+- Add the following settings to `.vscode/settings.json` inside your _workspace_
+
+> **Warning**
+> We don't recommend to set these settings in your global settings, because they depend on this eslint-config being used in your project.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -43,20 +43,22 @@ For example:
 
 ### VS Code support (auto fix)
 
-- Install [VS Code ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+Install [VS Code ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 
-- Add the following settings to `.vscode/settings.json` inside your _workspace_
+Add the following settings to your `settings.json`:
 
-> **Warning**
-> We don't recommend to set these settings in your global settings, because they depend on this eslint-config being used in your project.
-
-```json
+```jsonc
 {
   "prettier.enable": false,
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,
     "source.organizeImports": false,
+
+    // The following is optional.
+    // It's better to put under project setting `.vscode/settings.json`
+    // to avoid conflicts with working with different eslint configs
+    // that does not support all formats.
     "eslint.validate": [
       "javascript",
       "javascriptreact",

--- a/README.md
+++ b/README.md
@@ -51,7 +51,19 @@ Install [VS Code ESLint extension](https://marketplace.visualstudio.com/items?it
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,
-    "source.organizeImports": false
+    "source.organizeImports": false,
+    "eslint.validate": [
+      "javascript",
+      "javascriptreact",
+      "typescript",
+      "typescriptreact",
+      "vue",
+      "html",
+      "markdown",
+      "json",
+      "jsonc",
+      "yaml"
+    ]
   }
 }
 ```


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR adds the recommended configuration for the ESLint VSCode extension to enable it to lint all supported filetypes from this eslint-config.

### Linked Issues

Fix #153

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
