### PR TITLE
feat: ban `new Array`

### DIFF
--- a/packages/eslint-config-basic/index.js
+++ b/packages/eslint-config-basic/index.js
@@ -368,6 +368,8 @@ module.exports = {
     'unicorn/prefer-node-protocol': 'error',
     // Prefer using number properties like `Number.isNaN` rather than `isNaN`
     'unicorn/prefer-number-properties': 'error',
+    // Ban `new Array` as `Array` constructor's params are ambiguous
+    'unicorn/no-new-array': 'error',
 
     'no-use-before-define': ['error', { functions: false, classes: false, variables: true }],
     'eslint-comments/disable-enable-pair': 'off',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The parameter of Array constructor is the design mistake which is ambiguous and hard to use. Banning this will be convenient for code review. Because some time I will forget:

```js
new Array(5) // An array with 5 items? Or one item in an array?
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
