### PR TITLE
feat(basic): prefer non global process object

### DIFF
--- a/packages/eslint-config-basic/index.js
+++ b/packages/eslint-config-basic/index.js
@@ -338,7 +338,7 @@ module.exports = {
     'max-statements-per-line': ['error', { max: 1 }],
 
     // node
-    // 'n/prefer-global/process': ['error', 'never'], // Not sure if we need it as we are using `process.env.NODE_ENV` a lot in front-end.
+    'n/prefer-global/process': ['error', 'never'],
     'n/prefer-global/buffer': ['error', 'never'],
     'n/no-callback-literal': 'off',
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I've re-thought it carefully.
- For people who use vite, they should use `import.meta.env.PROD`. See  https://vitejs.dev/guide/env-and-mode.html.
- For people who use webpack, they should use `new webpack.DefinePlugin({'import.meta.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)})` to inject it. See https://webpack.js.org/plugins/environment-plugin/

Any way, we should not use `process.env` in frontend projects. So enable this rule will benefit node projects.

BTW, why did not  vite document mention the `process.env` but `import.meta.env`? Maybe vite author do not recommend us to use `process.env` in frontend project. 😆

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

https://github.com/antfu/eslint-config/pull/159

<!-- e.g. is there anything you'd like reviewers to focus on? -->
