### PR TITLE
docs: VS Code config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,24 +54,24 @@ Add the following settings to your `settings.json`:
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,
     "source.organizeImports": false,
-
-    // The following is optional.
-    // It's better to put under project setting `.vscode/settings.json`
-    // to avoid conflicts with working with different eslint configs
-    // that does not support all formats.
-    "eslint.validate": [
-      "javascript",
-      "javascriptreact",
-      "typescript",
-      "typescriptreact",
-      "vue",
-      "html",
-      "markdown",
-      "json",
-      "jsonc",
-      "yaml"
-    ]
-  }
+  },
+  
+  // The following is optional.
+  // It's better to put under project setting `.vscode/settings.json`
+  // to avoid conflicts with working with different eslint configs
+  // that does not support all formats.
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "vue",
+    "html",
+    "markdown",
+    "json",
+    "jsonc",
+    "yaml"
+  ]
 }
 ```
 


### PR DESCRIPTION
### Description

Fixes a mistake in a code example in the README.md file.  The `eslint.validate` option was mistakenly inside the `editor.codeActionsOnSave` option.
