### PR TITLE
fix(plugin): allow empty type import

### DIFF
--- a/packages/eslint-plugin-antfu/src/rules/prefer-inline-type-import.test.ts
+++ b/packages/eslint-plugin-antfu/src/rules/prefer-inline-type-import.test.ts
@@ -6,6 +6,7 @@ const valids = [
   'import { type Foo } from \'foo\'',
   'import type Foo from \'foo\'',
   'import type * as Foo from \'foo\'',
+  'import type {} from \'foo\'',
 ]
 const invalids = [
   ['import type { Foo } from \'foo\'', 'import { type Foo } from \'foo\''],

--- a/packages/eslint-plugin-antfu/src/rules/prefer-inline-type-import.ts
+++ b/packages/eslint-plugin-antfu/src/rules/prefer-inline-type-import.ts
@@ -30,7 +30,7 @@ export default createEslintRule<Options, MessageIds>({
         // ignore bare type imports
         if (node.specifiers.length === 1 && ['ImportNamespaceSpecifier', 'ImportDefaultSpecifier'].includes(node.specifiers[0].type))
           return
-        if (node.importKind === 'type') {
+        if (node.importKind === 'type' && node.specifiers.length > 0) {
           context.report({
             *fix(fixer) {
               yield * removeTypeSpecifier(fixer, sourceCode, node)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Allow the case below, instead of removing `type` keyword
```ts
import type {} from 'vite'
```

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
