### PR TITLE
feat: format for named tuple

### DIFF
--- a/packages/eslint-config-ts/index.js
+++ b/packages/eslint-config-ts/index.js
@@ -161,6 +161,7 @@ module.exports = {
     'antfu/no-cjs-exports': 'error',
     'antfu/no-ts-export-equal': 'error',
     'antfu/no-const-enum': 'error',
+    'antfu/named-tuple-spacing': 'error',
 
     // off
     '@typescript-eslint/consistent-indexed-object-style': 'off',

--- a/packages/eslint-plugin-antfu/src/index.ts
+++ b/packages/eslint-plugin-antfu/src/index.ts
@@ -6,6 +6,7 @@ import topLevelFunction from './rules/top-level-function'
 import noTsExportEqual from './rules/no-ts-export-equal'
 import noCjsExports from './rules/no-cjs-exports'
 import noConstEnum from './rules/no-const-enum'
+import namedTupleSpacing from './rules/named-tuple-spacing'
 
 export default {
   rules: {
@@ -17,5 +18,6 @@ export default {
     'no-cjs-exports': noCjsExports,
     'no-ts-export-equal': noTsExportEqual,
     'no-const-enum': noConstEnum,
+    'named-tuple-spacing': namedTupleSpacing,
   },
 }

--- a/packages/eslint-plugin-antfu/src/rules/named-tuple-spacing.test.ts
+++ b/packages/eslint-plugin-antfu/src/rules/named-tuple-spacing.test.ts
@@ -1,0 +1,46 @@
+import { RuleTester } from '@typescript-eslint/utils/dist/ts-eslint'
+import { it } from 'vitest'
+import type { MessageIds } from './named-tuple-spacing'
+import rule, { RULE_NAME } from './named-tuple-spacing'
+
+const valids = [
+  'type T = [i: number]',
+  'type T = [i:   number]', // passes since it will be handled by eslint's no-multi-spaces
+  'type T = [i: number, j: number]',
+  `const emit = defineEmits<{
+    change: [id: number]
+    update: [value: string]
+  }>()`,
+]
+
+const invalids = [
+  ['type T = [i:number]', 'type T = [i: number]'],
+  ['type T = [i : number]', 'type T = [i: number]', 1, 'unexpectedSpaceBefore'],
+  ['type T = [i:number, j:number]', 'type T = [i: number, j: number]', 2],
+  [
+    `const emit = defineEmits<{
+      change: [id:number]
+      update: [value:string]
+    }>()`,
+    `const emit = defineEmits<{
+      change: [id: number]
+      update: [value: string]
+    }>()`,
+    2,
+  ],
+] as [error: string, correct: string, errorNumber: number | undefined, errorMsg: MessageIds | undefined][]
+
+it('runs', () => {
+  const ruleTester: RuleTester = new RuleTester({
+    parser: require.resolve('@typescript-eslint/parser'),
+  })
+
+  ruleTester.run(RULE_NAME, rule, {
+    valid: valids,
+    invalid: invalids.map(i => ({
+      code: i[0],
+      output: i[1].trim(),
+      errors: Array.from({ length: i[2] || 1 }, () => ({ messageId: i[3] || 'expectedSpaceAfter' })),
+    })),
+  })
+})

--- a/packages/eslint-plugin-antfu/src/rules/named-tuple-spacing.test.ts
+++ b/packages/eslint-plugin-antfu/src/rules/named-tuple-spacing.test.ts
@@ -1,34 +1,16 @@
 import { RuleTester } from '@typescript-eslint/utils/dist/ts-eslint'
 import { it } from 'vitest'
-import type { MessageIds } from './named-tuple-spacing'
 import rule, { RULE_NAME } from './named-tuple-spacing'
 
 const valids = [
   'type T = [i: number]',
-  'type T = [i:   number]', // passes since it will be handled by eslint's no-multi-spaces
+  'type T = [i?: number]',
   'type T = [i: number, j: number]',
   `const emit = defineEmits<{
     change: [id: number]
     update: [value: string]
   }>()`,
 ]
-
-const invalids = [
-  ['type T = [i:number]', 'type T = [i: number]'],
-  ['type T = [i : number]', 'type T = [i: number]', 1, 'unexpectedSpaceBefore'],
-  ['type T = [i:number, j:number]', 'type T = [i: number, j: number]', 2],
-  [
-    `const emit = defineEmits<{
-      change: [id:number]
-      update: [value:string]
-    }>()`,
-    `const emit = defineEmits<{
-      change: [id: number]
-      update: [value: string]
-    }>()`,
-    2,
-  ],
-] as [error: string, correct: string, errorNumber: number | undefined, errorMsg: MessageIds | undefined][]
 
 it('runs', () => {
   const ruleTester: RuleTester = new RuleTester({
@@ -37,10 +19,77 @@ it('runs', () => {
 
   ruleTester.run(RULE_NAME, rule, {
     valid: valids,
-    invalid: invalids.map(i => ({
-      code: i[0],
-      output: i[1].trim(),
-      errors: Array.from({ length: i[2] || 1 }, () => ({ messageId: i[3] || 'expectedSpaceAfter' })),
-    })),
+    invalid: [
+      {
+        code: 'type T = [i:number]',
+        output: 'type T = [i: number]',
+        errors: [{ messageId: 'expectedSpaceAfter' }],
+      },
+      {
+        code: 'type T = [i:  number]',
+        output: 'type T = [i: number]',
+        errors: [{ messageId: 'expectedSpaceAfter' }],
+      },
+      {
+        code: 'type T = [i?:number]',
+        output: 'type T = [i?: number]',
+        errors: [{ messageId: 'expectedSpaceAfter' }],
+      },
+      {
+        code: 'type T = [i?   :number]',
+        output: 'type T = [i?: number]',
+        errors: [{ messageId: 'unexpectedSpaceBetween' }, { messageId: 'expectedSpaceAfter' }],
+      },
+      {
+        code: 'type T = [i : number]',
+        output: 'type T = [i: number]',
+        errors: [{ messageId: 'unexpectedSpaceBefore' }],
+      },
+      {
+        code: 'type T = [i  : number]',
+        output: 'type T = [i: number]',
+        errors: [{ messageId: 'unexpectedSpaceBefore' }],
+      },
+      {
+        code: 'type T = [i  ?  : number]',
+        output: 'type T = [i?: number]',
+        errors: [{ messageId: 'unexpectedSpaceBetween' }, { messageId: 'unexpectedSpaceBefore' }],
+      },
+      {
+        code: 'type T = [i:number, j:number]',
+        output: 'type T = [i: number, j: number]',
+        errors: [{ messageId: 'expectedSpaceAfter' }, { messageId: 'expectedSpaceAfter' }],
+      },
+      {
+        code: `
+        const emit = defineEmits<{
+          change: [id:number]
+          update: [value:string]
+        }>()
+        `,
+        output: `
+        const emit = defineEmits<{
+          change: [id: number]
+          update: [value: string]
+        }>()
+        `,
+        errors: [{ messageId: 'expectedSpaceAfter' }, { messageId: 'expectedSpaceAfter' }],
+      },
+      {
+        code: `
+        const emit = defineEmits<{
+          change: [id? :number]
+          update: [value:string]
+        }>()
+        `,
+        output: `
+        const emit = defineEmits<{
+          change: [id?: number]
+          update: [value: string]
+        }>()
+        `,
+        errors: [{ messageId: 'unexpectedSpaceBetween' }, { messageId: 'expectedSpaceAfter' }, { messageId: 'expectedSpaceAfter' }],
+      },
+    ],
   })
 })

--- a/packages/eslint-plugin-antfu/src/rules/named-tuple-spacing.ts
+++ b/packages/eslint-plugin-antfu/src/rules/named-tuple-spacing.ts
@@ -1,0 +1,55 @@
+import { createEslintRule } from '../utils'
+
+export const RULE_NAME = 'named-tuple-spacing'
+export type MessageIds = 'expectedSpaceAfter' | 'unexpectedSpaceBefore'
+export type Options = []
+
+export default createEslintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Expect space before type declaration in named tuple',
+      recommended: 'error',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      expectedSpaceAfter: 'Expected a space after the \':\'.',
+      unexpectedSpaceBefore: 'Unexpected space(s) before the \':\'.',
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    const sourceCode = context.getSourceCode()
+    return {
+      TSNamedTupleMember: (node) => {
+        const code = sourceCode.text.slice(node.range[0], node.range[1])
+
+        const reg = /(\w+)( *):( *)(\w+)/
+        const spacesBeforeColon = code.match(reg)?.[2]
+        const spacesAfterColon = code.match(reg)?.[3]
+
+        if (spacesBeforeColon?.length) {
+          context.report({
+            node,
+            messageId: 'unexpectedSpaceBefore',
+            *fix(fixer) {
+              yield fixer.replaceTextRange(node.range, code.replace(reg, '$1: $4'))
+            },
+          })
+        }
+
+        if (!spacesAfterColon) {
+          context.report({
+            node,
+            messageId: 'expectedSpaceAfter',
+            *fix(fixer) {
+              yield fixer.replaceTextRange(node.range, code.replace(reg, '$1: $4'))
+            },
+          })
+        }
+      },
+    }
+  },
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Vue 3.3 provides [a new way to define props](https://vuejs.org/guide/typescript/composition-api.html#typing-component-emits), which leverages [named tuples](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#labeled-tuple-elements): 

```ts
const emit = defineEmits<{
  change: [id: number]
  update: [value: string]
}>()
```

However, I didn't find a ESLint rule that checks spaces between colon in named tuples. It would be nice to have one. 

```ts
// good
type T = [i: number]

const emit = defineEmits<{
    change: [id: number]
    update: [value: string]
}>()
```

```ts
// bad
type T = [i:number]
type T = [i : number]

const emit = defineEmits<{
    change: [id:number]
    update: [value:string]
}>()
```

### Linked Issues


### Additional context

