### PR TITLE
fix(basic): ignore vitepress cache files

### DIFF
--- a/packages/eslint-config-basic/index.js
+++ b/packages/eslint-config-basic/index.js
@@ -43,7 +43,7 @@ module.exports = {
     '!.vitepress',
     '!.vscode',
     // force exclude
-    '.vitepress/cache',
+    '**/.vitepress/cache',
   ],
   plugins: [
     'html',


### PR DESCRIPTION
### Description

`.vitepress/cache` is can not ignore `docs/.vitepress/cache/**` in monorepo app.

ignorePatterns change:

`.vitepress/cache` -> `**/.vitepress/cache`