### PR TITLE
feat(vue): replace deprecate rules of vue

### DIFF
--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -39,9 +39,9 @@ module.exports = {
     'vue/no-dupe-keys': 'off',
 
     // reactivity transform
-    'vue/no-setup-props-destructure': 'off',
+    'vue/no-setup-props-reactivity-loss': 'off',
 
-    'vue/component-tags-order': ['error', {
+    'vue/block-order': ['error', {
       order: ['script', 'template', 'style'],
     }],
     'vue/block-tag-newline': ['error', {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Two rules of `vue` are deprecated and replaced by others.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
1. [`vue/component-tags-order`](https://eslint.vuejs.org/rules/component-tags-order.html) was deprecated and replaced by [`vue/block-order`](https://eslint.vuejs.org/rules/block-order) rule.
2. [`vue/no-setup-props-destructure`](https://eslint.vuejs.org/rules/no-setup-props-destructure.html) was deprecated and replaced by [`vue/no-setup-props-reactivity-loss`](https://eslint.vuejs.org/rules/no-setup-props-reactivity-loss.html) rule.
