### PR TITLE
fix(basic): JavaScript vue import error

### DIFF
--- a/packages/eslint-config-basic/index.js
+++ b/packages/eslint-config-basic/index.js
@@ -233,6 +233,7 @@ module.exports = {
     'import/no-absolute-path': 'off',
     'import/newline-after-import': ['error', { count: 1, considerComments: true }],
     'import/no-self-import': 'error',
+    'import/named': 'off',
 
     // Common
     'semi': ['error', 'never'],
@@ -412,7 +413,7 @@ module.exports = {
 
     // jsdoc
     'jsdoc/require-jsdoc': 'off',
-    "jsdoc/require-param": 'off',
+    'jsdoc/require-param': 'off',
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-param-description': 'off',
     'jsdoc/require-yields': 'off',
@@ -422,7 +423,7 @@ module.exports = {
     'jsdoc/no-undefined-types': 'off',
     'jsdoc/require-returns': 'off',
     'jsdoc/require-returns-type': 'off',
-    "jsdoc/require-throws": 'off',
+    'jsdoc/require-throws': 'off',
 
     // antfu
     'antfu/no-import-node-modules-by-path': 'error',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
When I use import { createApp } from 'vue' in JavaScript file,eslint error `createApp not found in 'vue'`,not install TypeScript
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
