### PR TITLE
fix: revert '@stylistic/ts/comma-dangle' rule

### DIFF
--- a/packages/eslint-config-basic/index.js
+++ b/packages/eslint-config-basic/index.js
@@ -218,7 +218,7 @@ module.exports = {
         '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/no-require-imports': 'off',
 
-        '@stylistic/ts/comma-dangle': 'off',
+        '@typescript-eslint/comma-dangle': 'off',
    
         'unused-imports/no-unused-imports': 'off',
         'unused-imports/no-unused-vars': 'off',

--- a/packages/eslint-config-ts/index.js
+++ b/packages/eslint-config-ts/index.js
@@ -222,10 +222,8 @@ module.exports = {
     '@typescript-eslint/quotes': ['error', 'single'],
     'no-extra-parens': 'off',
     '@typescript-eslint/no-extra-parens': ['error', 'functions'],
-
-    // Stylistic JS/TS Misalignments (should be fixed upstream)
     'comma-dangle': 'off',
-    '@stylistic/ts/comma-dangle': ['error', 'always-multiline'],
+    '@typescript-eslint/comma-dangle': ['error', 'always-multiline'],
 
     // Stylistic JS/TS
     '@stylistic/js/space-before-blocks': 'off',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

fix: Definition for rule '@stylistic/ts/comma-dangle' was not found

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
