### PR TITLE
test: fix js test on windows

### DIFF
--- a/test/foo.test.ts
+++ b/test/foo.test.ts
@@ -54,7 +54,9 @@ export default antfu(${JSON.stringify(configs)})
   })
 
   for (const file of files) {
-    const content = await fs.readFile(join(target, file), 'utf-8')
+    let content = await fs.readFile(join(target, file), 'utf-8')
+    if (content.match(/\r\n/))
+      content = content.replace(/\r\n|\r/g, '\n')
     await expect.soft(content).toMatchFileSnapshot(join(output, file))
   }
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fix the `Snapshot 'js 1' mismatched` failed test on windows.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

`style/brace-style` insert a `\n` before `catch` insteadof `\r\n`, which mismatches the snapshot file.

`toMatchFileSnapshot()` on windows:

excepted:
```
"... JSON.parse('invalid JSON')\r\n}\r\ncatch (error) {\r\n..."
```

receivedSerialized:
```
"... JSON.parse('invalid JSON')\r\n}\ncatch (error) {\r\n..."
```

I'm not quite sure should this problem been addressed at the root by the ESLint rule itself or Vitest.

BTW, [about another failed testcase on windows.](https://github.com/antfu/eslint-plugin-antfu/pull/1)

