### PR TITLE
fix: yaml indent

### DIFF
--- a/src/configs/yaml.ts
+++ b/src/configs/yaml.ts
@@ -12,6 +12,7 @@ export function yaml(
   } = options
 
   const {
+    indent = 2,
     quotes = 'single',
   } = typeof stylistic === 'boolean' ? {} : stylistic
 
@@ -48,7 +49,7 @@ export function yaml(
               'yaml/flow-mapping-curly-spacing': 'error',
               'yaml/flow-sequence-bracket-newline': 'error',
               'yaml/flow-sequence-bracket-spacing': 'error',
-              'yaml/indent': ['error', 2],
+              'yaml/indent': ['error', indent === 'tabs' ? 2 : indent],
               'yaml/key-spacing': 'error',
               'yaml/no-tab-indent': 'error',
               'yaml/quotes': ['error', { avoidEscape: false, prefer: quotes }],

--- a/src/configs/yaml.ts
+++ b/src/configs/yaml.ts
@@ -49,7 +49,7 @@ export function yaml(
               'yaml/flow-mapping-curly-spacing': 'error',
               'yaml/flow-sequence-bracket-newline': 'error',
               'yaml/flow-sequence-bracket-spacing': 'error',
-              'yaml/indent': ['error', indent === 'tabs' ? 2 : indent],
+              'yaml/indent': ['error', indent === 'tab' ? 2 : indent],
               'yaml/key-spacing': 'error',
               'yaml/no-tab-indent': 'error',
               'yaml/quotes': ['error', { avoidEscape: false, prefer: quotes }],

--- a/src/configs/yaml.ts
+++ b/src/configs/yaml.ts
@@ -12,7 +12,6 @@ export function yaml(
   } = options
 
   const {
-    indent = 2,
     quotes = 'single',
   } = typeof stylistic === 'boolean' ? {} : stylistic
 
@@ -49,9 +48,9 @@ export function yaml(
               'yaml/flow-mapping-curly-spacing': 'error',
               'yaml/flow-sequence-bracket-newline': 'error',
               'yaml/flow-sequence-bracket-spacing': 'error',
-              'yaml/indent': ['error', indent],
+              'yaml/indent': ['error', 2],
               'yaml/key-spacing': 'error',
-              'yaml/no-tab-indent': indent === 'tab' ? 'off' : 'error',
+              'yaml/no-tab-indent': 'error',
               'yaml/quotes': ['error', { avoidEscape: false, prefer: quotes }],
               'yaml/spaced-comment': 'error',
             }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Using tabs in yaml is a syntax error nor a valid argument value of `yaml/indent`, so we should enforce 2 spaces when user uses tabs.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
