### PR TITLE
chore(unicorn): remove deprecated rule `no-unsafe-regex`

### DIFF
--- a/src/configs/unicorn.ts
+++ b/src/configs/unicorn.ts
@@ -19,8 +19,6 @@ export function unicorn(): FlatESLintConfigItem[] {
         'unicorn/no-new-array': 'error',
         // Prevent deprecated `new Buffer()`
         'unicorn/no-new-buffer': 'error',
-        // Keep regex literals safe!
-        'unicorn/no-unsafe-regex': 'error',
         // Lowercase number formatting for octal, hex, binary (0x1'error' instead of 0X1'error')
         'unicorn/number-literal-case': 'error',
         // includes over indexOf when checking for existence


### PR DESCRIPTION
The `no-unsafe-regex` rule from eslint-plugin-unicorn has already been deprecated in https://github.com/sindresorhus/eslint-plugin-unicorn/pull/2135
