### PR TITLE
feat: update jsx default config

### DIFF
--- a/fixtures/output/all/tsx.tsx
+++ b/fixtures/output/all/tsx.tsx
@@ -4,14 +4,18 @@ export function Component1() {
 
 export function jsx2() {
   const props = { a: 1, b: 2 }
-  return (<a foo="bar" bar={`foo`} >
-    <div
-      {...props}
-      a={1}
-      b="2"
-    >Inline Text</div>
-    <Component1>
-      Block Text
-    </Component1>
-  </a >)
+  return (
+    <a foo="bar" bar="foo">
+      <div
+        {...props}
+        a={1}
+        b="2"
+      >
+        Inline Text
+      </div>
+      <Component1>
+        Block Text
+      </Component1>
+    </a>
+  )
 }

--- a/fixtures/output/tab-double-quotes/tsx.tsx
+++ b/fixtures/output/tab-double-quotes/tsx.tsx
@@ -4,14 +4,18 @@ export function Component1() {
 
 export function jsx2() {
 	const props = { a: 1, b: 2 }
-	return (<a foo="bar" bar={`foo`} >
-		<div
-			{...props}
-			a={1}
-			b="2"
-		>Inline Text</div>
-		<Component1>
-			Block Text
-		</Component1>
-	</a >)
+	return (
+		<a foo="bar" bar="foo">
+			<div
+				{...props}
+				a={1}
+				b="2"
+			>
+				Inline Text
+			</div>
+			<Component1>
+				Block Text
+			</Component1>
+		</a>
+	)
 }

--- a/fixtures/output/ts-override/tsx.tsx
+++ b/fixtures/output/ts-override/tsx.tsx
@@ -4,14 +4,18 @@ export function Component1() {
 
 export function jsx2() {
   const props = { a: 1, b: 2 }
-  return (<a foo="bar" bar={`foo`} >
-    <div
-      {...props}
-      a={1}
-      b="2"
-    >Inline Text</div>
-    <Component1>
-      Block Text
-    </Component1>
-  </a >)
+  return (
+    <a foo="bar" bar="foo">
+      <div
+        {...props}
+        a={1}
+        b="2"
+      >
+        Inline Text
+      </div>
+      <Component1>
+        Block Text
+      </Component1>
+    </a>
+  )
 }

--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -128,16 +128,38 @@ export function stylistic(options: StylisticConfig = {}): ConfigItem[] {
         ...jsx
           ? {
               'style/jsx-child-element-spacing': 'error',
-              'style/jsx-closing-bracket-location': ['error', 'line-aligned'],
+              'style/jsx-closing-bracket-location': 'error',
+              'style/jsx-closing-tag-location': 'error',
+              'style/jsx-curly-brace-presence': ['error', { propElementValues: 'always' }],
               'style/jsx-curly-newline': 'error',
-              'style/jsx-curly-spacing': ['error', 'never', { allowMultiline: true }],
+              'style/jsx-curly-spacing': ['error', 'never'],
               'style/jsx-equals-spacing': 'error',
               'style/jsx-first-prop-new-line': 'error',
-              'style/jsx-indent': ['error', indent],
+              'style/jsx-indent': ['error', indent, { checkAttributes: false, indentLogicalExpressions: true }],
               'style/jsx-indent-props': ['error', indent],
+              'style/jsx-max-props-per-line': ['error', { maximum: 1, when: 'multiline' }],
               'style/jsx-quotes': 'error',
-              'style/jsx-tag-spacing': 'error',
-              'style/jsx-wrap-multilines': 'error',
+              'style/jsx-tag-spacing': [
+                'error',
+                {
+                  afterOpening: 'never',
+                  beforeClosing: 'never',
+                  beforeSelfClosing: 'always',
+                  closingSlash: 'never',
+                },
+              ],
+              'style/jsx-wrap-multilines': [
+                'error',
+                {
+                  arrow: 'parens-new-line',
+                  assignment: 'parens-new-line',
+                  condition: 'parens-new-line',
+                  declaration: 'parens-new-line',
+                  logical: 'parens-new-line',
+                  prop: 'parens-new-line',
+                  return: 'parens-new-line',
+                },
+              ],
             }
           : {},
       },

--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -135,9 +135,10 @@ export function stylistic(options: StylisticConfig = {}): ConfigItem[] {
               'style/jsx-curly-spacing': ['error', 'never'],
               'style/jsx-equals-spacing': 'error',
               'style/jsx-first-prop-new-line': 'error',
-              'style/jsx-indent': ['error', indent, { checkAttributes: false, indentLogicalExpressions: true }],
+              'style/jsx-indent': ['error', indent, { checkAttributes: true, indentLogicalExpressions: true }],
               'style/jsx-indent-props': ['error', indent],
               'style/jsx-max-props-per-line': ['error', { maximum: 1, when: 'multiline' }],
+              'style/jsx-one-expression-per-line': ['error', { allow: 'single-child' }],
               'style/jsx-quotes': 'error',
               'style/jsx-tag-spacing': [
                 'error',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Update the JSX configuration to make it resemble the formatting of Prettier(Not 100% consistent).


### Linked Issues

[#185](https://github.com/antfu/eslint-config/issues/185)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

In many projects, JSX files are typically automatically formatted using Prettier, such as in Next.js. Therefore, there's often no need to configure JSX rules in eslint-plugin-react to achieve a consistent JSX format.

Now, if we want to use ESLint for JSX formatting instead of Prettier, it would be beneficial to ensure that the JSX configuration closely matches the formatting produced by Prettier for consistency.

I use jsx a lot, so I configured eslint rules according to the prettier style. Due to the limitations of eslint jsx rules, it is not yet completely consistent with Prettier and can only be as similar as possible. Perhaps it can be optimized in the future.
