### PR TITLE
chore: run `nr dev` scripts concurrently on windows

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 strict-peer-dependencies=false
 shamefully-hoist=true
 ignore-workspace-root-check=true
+shell-emulator=true


### PR DESCRIPTION
This PR is in draft while I check that the problem mentioned in https://github.com/antfu/eslint-config/issues/284#issuecomment-1761587177 is not a result of this change.

### Description

`nr dev` runs tsup in watch mode and eslint-flat-config-viewer. Both commands run indefinitely and therefore need to be executed concurrently. I assume that this is achieved by the & sign on Unix-based systems, however on my Windows systems only the first command is executed.

This is fixed by enabling shell-emulator as suggested in https://github.com/antfu/eslint-config/issues/284 by @antfu.


### Linked Issues

Closes #284 



