### PR TITLE
fix: enforce name casing for unregistered components

### DIFF
--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -47,7 +47,9 @@ export function vue(
         'vue/block-order': ['error', {
           order: ['script', 'template', 'style'],
         }],
-        'vue/component-name-in-template-casing': ['error', 'PascalCase'],
+        'vue/component-name-in-template-casing': ['error', 'PascalCase', {
+          registeredComponentsOnly: false,
+        }],
         'vue/component-options-name-casing': ['error', 'PascalCase'],
         'vue/custom-event-name-casing': ['error', 'camelCase'],
         'vue/define-macros-order': ['error', {


### PR DESCRIPTION
fix #288
added optional param for `vue/component-name-in-template-casing`

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
vue/component-name-in-template-casing doesn't work when the component is global or auto-imported (like in nuxt).
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
#288 


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
