### PR TITLE
fix(vue): no pascal case for `<component>` built-in element

### DIFF
--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -49,6 +49,7 @@ export function vue(
         }],
         'vue/component-name-in-template-casing': ['error', 'PascalCase', {
           registeredComponentsOnly: false,
+          ignores: ['component'],
         }],
         'vue/component-options-name-casing': ['error', 'PascalCase'],
         'vue/custom-event-name-casing': ['error', 'camelCase'],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The `vue/component-name-in-template-casing` rule enforces pascal-cased component names. This will also enforce `<component>` to be written as `<Component>`, which is not correct. Technically, `<component>` is not a component, but an element.

As the [Vue docs state](https://vuejs.org/api/built-in-special-elements.html):

> [!NOTE]
> `<component>`, `<slot>` and `<template>` are component-like features and part of the template syntax. They are not true components and are compiled away during template compilation. As such, they are conventionally written with lowercase in templates.

### Linked Issues

None.

### Additional context

Just want to thank you for this ESLint configs masterpiece!
