### PR TITLE
fix: revert #289

### DIFF
--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -47,9 +47,7 @@ export function vue(
         'vue/block-order': ['error', {
           order: ['script', 'template', 'style'],
         }],
-        'vue/component-name-in-template-casing': ['error', 'PascalCase', {
-          registeredComponentsOnly: false,
-        }],
+        'vue/component-name-in-template-casing': ['error', 'PascalCase'],
         'vue/component-options-name-casing': ['error', 'PascalCase'],
         'vue/custom-event-name-casing': ['error', 'camelCase'],
         'vue/define-macros-order': ['error', {


### PR DESCRIPTION
This reverts commit ba704e78711236c34318470ff211956a13012ae0.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Reverting change as it breaks camel case components which are imported within SFC itself, even though it is valid SFC syntax. For example, using `framework7-vue` where component names are prefixed with `f7`:

```vue
<script setup lang="ts">
	import { f7Button } from 'framework7-vue'
</script>

<template>
	<f7Button>Hello</f7Button>
</template>
```

It will get fixed to 

```vue
<script setup lang="ts">
</script>

<template>
	<F7Button>Hello</F7Button>
</template>
```

Which is invalid.

### Linked Issues

NA

### Additional context

Related [comment](https://github.com/antfu/eslint-config/pull/289#issuecomment-1783870934).

<!-- e.g. is there anything you'd like reviewers to focus on? -->
