### PR TITLE
feat: typescript.tsconfigPath array support

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,8 +328,6 @@ import antfu from '@antfu/eslint-config'
 export default antfu({
   typescript: {
     tsconfigPath: 'tsconfig.json',
-    // or if you have multiple tsconfigs
-    tsconfigPath: ['tsconfig.json', 'tsconfig.node.json'],
   },
 })
 ```

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ import antfu from '@antfu/eslint-config'
 export default antfu({
   typescript: {
     tsconfigPath: 'tsconfig.json',
+    // or if you have multiple tsconfigs
+    tsconfigPath: ['tsconfig.json', 'tsconfig.node.json'],
   },
 })
 ```

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -2,7 +2,7 @@ import process from 'node:process'
 import type { ConfigItem, OptionsComponentExts, OptionsOverrides, OptionsTypeScriptParserOptions, OptionsTypeScriptWithTypes } from '../types'
 import { GLOB_SRC } from '../globs'
 import { parserTs, pluginAntfu, pluginImport, pluginTs } from '../plugins'
-import { renameRules } from '../utils'
+import { renameRules, toArray } from '../utils'
 
 export function typescript(
   options?: OptionsComponentExts & OptionsOverrides & OptionsTypeScriptWithTypes & OptionsTypeScriptParserOptions,
@@ -11,7 +11,6 @@ export function typescript(
     componentExts = [],
     overrides = {},
     parserOptions = {},
-    tsconfigPath: tsc,
   } = options ?? {}
 
   const typeAwareRules: ConfigItem['rules'] = {
@@ -36,11 +35,9 @@ export function typescript(
     'ts/unbound-method': 'error',
   }
 
-  const tsconfigPath = typeof tsc === 'string' && tsc.trim()
-    ? [tsc]
-    : Array.isArray(tsc) && tsc.length > 0
-      ? tsc
-      : null
+  const tsconfigPath = options?.tsconfigPath
+    ? toArray(options.tsconfigPath)
+    : undefined
 
   return [
     {

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -11,7 +11,7 @@ export function typescript(
     componentExts = [],
     overrides = {},
     parserOptions = {},
-    tsconfigPath,
+    tsconfigPath: tsc,
   } = options ?? {}
 
   const typeAwareRules: ConfigItem['rules'] = {
@@ -36,6 +36,12 @@ export function typescript(
     'ts/unbound-method': 'error',
   }
 
+  const tsconfigPath = typeof tsc === 'string' && tsc.trim()
+    ? [tsc]
+    : Array.isArray(tsc) && tsc.length > 0
+      ? tsc
+      : null
+
   return [
     {
       // Install the plugins without globs, so they can be configured separately.
@@ -58,7 +64,7 @@ export function typescript(
           sourceType: 'module',
           ...tsconfigPath
             ? {
-                project: [tsconfigPath],
+                project: tsconfigPath,
                 tsconfigRootDir: process.cwd(),
               }
             : {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,7 @@ export interface OptionsTypeScriptWithTypes {
    * When this options is provided, type aware rules will be enabled.
    * @see https://typescript-eslint.io/linting/typed-linting/
    */
-  tsconfigPath?: string
+  tsconfigPath?: string | string[]
 }
 
 export interface OptionsHasTypeScript {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,3 +17,7 @@ export function renameRules(rules: Record<string, any>, from: string, to: string
       }),
   )
 }
+
+export function toArray<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value]
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Multiple tsconfigs support
```ts
typescript: {
  tsconfigPath: ['tsconfig.json', 'tsconfig.node.json']
}
```

### Linked Issues
close #305 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
