### PR TITLE
fix: warning when running react

### DIFF
--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -45,6 +45,11 @@ export async function react(
         'react-hooks': pluginReactHooks,
         'react-refresh': pluginReactRefresh,
       },
+      settings: {
+        react: {
+          version: 'detect',
+        }
+      },
     },
     {
       files,

--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -48,7 +48,7 @@ export async function react(
       settings: {
         react: {
           version: 'detect',
-        }
+        },
       },
     },
     {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fix https://github.com/antfu/eslint-config/issues/341

When running the optional react config, it prints the following warning

`Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration`

this pr, fix the message above :)
### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
