### PR TITLE
fix: vue2 presets name

### DIFF
--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -72,9 +72,9 @@ export async function vue(
 
         ...vueVersion === 2
           ? {
-              ...pluginVue.configs['vue-essential'].rules as any,
-              ...pluginVue.configs['vue-strongly-recommended'].rules as any,
-              ...pluginVue.configs['vue-recommended'].rules as any,
+              ...pluginVue.configs.essential.rules as any,
+              ...pluginVue.configs['strongly-recommended'].rules as any,
+              ...pluginVue.configs.recommended.rules as any,
             }
           : {
               ...pluginVue.configs['vue3-essential'].rules as any,


### PR DESCRIPTION


### Description

use wrong key for vue2 presets. 

https://eslint.vuejs.org/rules/#priority-a-essential-error-prevention

### Linked Issues


### Additional context

![image](https://github.com/antfu/eslint-config/assets/23276822/98ae5c02-f5fb-405a-bf50-8d1c79fafe1a)
