### PR TITLE
feat: detect if in (n)vim editor

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -55,7 +55,7 @@ export async function antfu(
   const {
     componentExts = [],
     gitignore: enableGitignore = true,
-    isInEditor = !!((process.env.VSCODE_PID || process.env.JETBRAINS_IDE) && !process.env.CI),
+    isInEditor = !!((process.env.VSCODE_PID || process.env.JETBRAINS_IDE || process.env.VIM) && !process.env.CI),
     overrides = {},
     react: enableReact = false,
     typescript: enableTypeScript = isPackageExists('typescript'),


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Make `isInEditor` detect vim/nvim. Uses [`$VIM`](https://neovim.io/doc/user/starting.html#_-$vim-and-$vimruntime) env var for detection.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
