### PR TITLE
docs: enhanced "Lint Staged" part

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,9 @@ and then
 
 ```bash
 npm i -D lint-staged simple-git-hooks
+
+// to active the hooks
+npx simple-git-hooks
 ```
 
 ## View what rules are enabled


### PR DESCRIPTION
### Description

To enable the git hooks which are described in [Lint Staged](https://github.com/antfu/eslint-config?tab=readme-ov-file#lint-staged) you have to run `npx simple-git-hooks`.

This is not part of a automatic postinstall script.

Simple Git Hooks Documentation: [Add simple-git-hooks to the project](https://github.com/toplenboren/simple-git-hooks?tab=readme-ov-file#add-simple-git-hooks-to-the-project)

With this pull request I added the necessary command to the code block