### PR TITLE
fix: add override options type for stylistic (closes #391)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -291,7 +291,7 @@ export interface OptionsConfig extends OptionsComponentExts {
    *
    * @default true
    */
-  stylistic?: boolean | StylisticConfig
+  stylistic?: boolean | (StylisticConfig & OptionsOverrides)
 
   /**
    * Enable react rules.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fixed #391.

### Linked Issues

#391 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
If I didn't miss something, I think it's only a type change.

I aware that `OptionsVue`, `OptionsTypescript`, 'OptionsUnoCSS' etc extends `OptionsOverrides` directly, but `OptionsStylistic` and `StylisticConfig` seems has different usages.