### PR TITLE
fix(svelte): disable style/indent in svelte files

### DIFF
--- a/src/configs/svelte.ts
+++ b/src/configs/svelte.ts
@@ -88,6 +88,7 @@ export async function svelte(
 
         ...stylistic
           ? {
+              'style/indent': 'off', // superseded by svelte/indent
               'style/no-trailing-spaces': 'off', // superseded by svelte/no-trailing-spaces
               'svelte/derived-has-same-inputs-outputs': 'error',
               'svelte/html-closing-bracket-spacing': 'error',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Turn off `style/indent` in favor `svelte/indent` as per [docs](https://sveltejs.github.io/eslint-plugin-svelte/rules/indent/). This is only applicable to `*.svelte` files.
### Linked Issues
Fix #399 

### Additional context
Not sure how this flew under the radar this long
<!-- e.g. is there anything you'd like reviewers to focus on? -->
