### PR TITLE
fix(imports): move no-unused-imports from js to imports config

### DIFF
--- a/src/configs/imports.ts
+++ b/src/configs/imports.ts
@@ -1,9 +1,10 @@
-import type { FlatConfigItem, OptionsStylistic } from '../types'
+import type { FlatConfigItem, OptionsIsInEditor, OptionsStylistic } from '../types'
 import { pluginAntfu, pluginImport } from '../plugins'
 import { GLOB_SRC_EXT } from '../globs'
 
-export async function imports(options: OptionsStylistic = {}): Promise<FlatConfigItem[]> {
+export async function imports(options: OptionsIsInEditor & OptionsStylistic = {}): Promise<FlatConfigItem[]> {
   const {
+    isInEditor = false,
     stylistic = true,
   } = options
 
@@ -26,6 +27,7 @@ export async function imports(options: OptionsStylistic = {}): Promise<FlatConfi
         'import/no-self-import': 'error',
         'import/no-webpack-loader-syntax': 'error',
         'import/order': 'error',
+        'unused-imports/no-unused-imports': isInEditor ? 'off' : 'error',
 
         ...stylistic
           ? {

--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -1,13 +1,12 @@
 import globals from 'globals'
-import type { FlatConfigItem, OptionsIsInEditor, OptionsOverrides } from '../types'
+import type { FlatConfigItem, OptionsOverrides } from '../types'
 import { pluginAntfu, pluginUnusedImports } from '../plugins'
 import { GLOB_SRC, GLOB_SRC_EXT } from '../globs'
 
 export async function javascript(
-  options: OptionsIsInEditor & OptionsOverrides = {},
+  options: OptionsOverrides = {},
 ): Promise<FlatConfigItem[]> {
   const {
-    isInEditor = false,
     overrides = {},
   } = options
 
@@ -200,7 +199,6 @@ export async function javascript(
 
         'symbol-description': 'error',
         'unicode-bom': ['error', 'never'],
-        'unused-imports/no-unused-imports': isInEditor ? 'off' : 'error',
 
         'unused-imports/no-unused-vars': [
           'error',

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -90,7 +90,6 @@ export async function antfu(
   configs.push(
     ignores(),
     javascript({
-      isInEditor,
       overrides: getOverrides(options, 'javascript'),
     }),
     comments(),
@@ -99,6 +98,7 @@ export async function antfu(
       stylistic: stylisticOptions,
     }),
     imports({
+      isInEditor,
       stylistic: stylisticOptions,
     }),
     unicorn(),


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
I've noticed that with the basic config the `unused-imports/no-unused-imports` rule works but with an overloaded config it doesn't apply correctly to `.ts` files so I've moved it to the `imports` config so that it's applied correctly even with an overloaded config.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
