### PR TITLE
feat: add `unused-imports/no-unused-imports-ts` rule

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -132,6 +132,7 @@ export async function typescript(
         'ts/prefer-ts-expect-error': 'error',
         'ts/triple-slash-reference': 'off',
         'ts/unified-signatures': 'off',
+        'unused-imports/no-unused-imports-ts': 'error',
         ...overrides,
       },
     },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
I noticed that the auto-fix of unused imports didn't work well for `.ts` files, using the config-viewer I noticed that a rule was unused and activating it worked so I suggest adding it.

![image](https://github.com/antfu/eslint-config/assets/26674548/8d357b69-7300-4f6f-8d83-85882138b46c)
### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
