### PR TITLE
fix: ignore `.yarn` folder

### DIFF
--- a/src/globs.ts
+++ b/src/globs.ts
@@ -72,6 +72,7 @@ export const GLOB_EXCLUDE = [
   '**/.cache',
   '**/.output',
   '**/.vite-inspect',
+  '**/.yarn',
 
   '**/CHANGELOG*.md',
   '**/*.min.*',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Ignore the `.yarn` folder by default. The folder is created by yarn berry and contains its minified source code with an unlimited `/* eslint-disable */` comment, which upsets the `eslint-comments/no-unlimited-disable` rule.

### Linked Issues

N/A

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

N/A
