### PR TITLE
docs: changed the default value for astro config and add description …

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -50,6 +50,13 @@ const VuePackages = [
 
 /**
  * Construct an array of ESLint flat config items.
+ *
+ * @param {OptionsConfig & FlatConfigItem} options
+ *  The options for generating the ESLint configurations.
+ * @param {Awaitable<UserConfigItem | UserConfigItem[]>[]} userConfigs
+ *  The user configurations to be merged with the generated configurations.
+ * @returns {Promise<UserConfigItem[]>}
+ *  The merged ESLint configurations.
  */
 export async function antfu(
   options: OptionsConfig & FlatConfigItem = {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -296,7 +296,13 @@ export interface OptionsConfig extends OptionsComponentExts {
   /**
    * Enable ASTRO support.
    *
-   * @default true
+   * Requires installing:
+   * - `eslint-plugin-astro`
+   *
+   * Requires installing for formatting .astro:
+   * - `prettier-plugin-astro`
+   *
+   * @default false
    */
   astro?: boolean | OptionsOverrides
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
By default, the jsdoc says `astro` is enabled(`true`), although as i understand it and as the doc suggests, it should be disabled(`false`)

I would also suggest adding a description for the constructor function(antfu) in the jsdoc, for easier visualization when using it

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
