### PR TITLE
feat: graphql glob that supports .qgl extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ Add the following settings to your `.vscode/settings.json`:
     "json",
     "jsonc",
     "yaml",
-    "toml"
+    "toml",
+    "gql",
+    "graphql"
   ]
 }
 ```

--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -1,5 +1,5 @@
 import { isPackageExists } from 'local-pkg'
-import { GLOB_ASTRO, GLOB_CSS, GLOB_LESS, GLOB_MARKDOWN, GLOB_POSTCSS, GLOB_SCSS } from '../globs'
+import { GLOB_ASTRO, GLOB_CSS, GLOB_GRAPHQL, GLOB_LESS, GLOB_MARKDOWN, GLOB_POSTCSS, GLOB_SCSS } from '../globs'
 import type { VendoredPrettierOptions } from '../vender/prettier-types'
 import { ensurePackages, interopDefault, parserPlain } from '../utils'
 import type { FlatConfigItem, OptionsFormatters, StylisticConfig } from '../types'
@@ -227,7 +227,7 @@ export async function formatters(
 
   if (options.graphql) {
     configs.push({
-      files: ['**/*.graphql'],
+      files: [GLOB_GRAPHQL],
       languageOptions: {
         parser: parserPlain,
       },

--- a/src/globs.ts
+++ b/src/globs.ts
@@ -25,6 +25,7 @@ export const GLOB_YAML = '**/*.y?(a)ml'
 export const GLOB_TOML = '**/*.toml'
 export const GLOB_HTML = '**/*.htm?(l)'
 export const GLOB_ASTRO = '**/*.astro'
+export const GLOB_GRAPHQL = '**/*.{g,graph}ql';
 
 export const GLOB_MARKDOWN_CODE = `${GLOB_MARKDOWN}/${GLOB_SRC}`
 

--- a/src/globs.ts
+++ b/src/globs.ts
@@ -25,7 +25,7 @@ export const GLOB_YAML = '**/*.y?(a)ml'
 export const GLOB_TOML = '**/*.toml'
 export const GLOB_HTML = '**/*.htm?(l)'
 export const GLOB_ASTRO = '**/*.astro'
-export const GLOB_GRAPHQL = '**/*.{g,graph}ql';
+export const GLOB_GRAPHQL = '**/*.{g,graph}ql'
 
 export const GLOB_MARKDOWN_CODE = `${GLOB_MARKDOWN}/${GLOB_SRC}`
 


### PR DESCRIPTION
### Description

Adding glob for GraphQL files. Currently only .graphql files are recognized. Another common and shorter filename is .gql.
Also added info about configuring eslint for VSCode to support gql files.

### Linked Issues


### Additional context

