### PR TITLE
chore: bump `@antfu/install-pkg` to ^0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     }
   },
   "dependencies": {
-    "@antfu/install-pkg": "^0.3.1",
+    "@antfu/install-pkg": "^0.3.2",
     "@clack/prompts": "^0.7.0",
     "@stylistic/eslint-plugin": "^1.7.0",
     "@typescript-eslint/eslint-plugin": "^7.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antfu/install-pkg':
-        specifier: ^0.3.1
-        version: 0.3.1
+        specifier: ^0.3.2
+        version: 0.3.2
       '@clack/prompts':
         specifier: ^0.7.0
         version: 0.7.0
@@ -251,8 +251,8 @@ packages:
       synckit: 0.8.8
     dev: true
 
-  /@antfu/install-pkg@0.3.1:
-    resolution: {integrity: sha512-A3zWY9VeTPnxlMiZtsGHw2lSd3ghwvL8s9RiGOtqvDxhhFfZ781ynsGBa/iUnDJ5zBrmTFQrJDud3TGgRISaxw==}
+  /@antfu/install-pkg@0.3.2:
+    resolution: {integrity: sha512-FFYqME8+UHlPnRlX/vn+8cTD4Wo/nG/lzRxpABs3XANBmdJdNImVz3QvjNAE/W3PSCNbG387FOz8o5WelnWOlg==}
     dependencies:
       execa: 8.0.1
     dev: false


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`@antfu/install-pkg` v0.3.2 enables installing dependencies on pnpm workspace, which can be very helpful if developers use `@antfu/eslint-config` and execute eslint on a pnpm workspace root directory. It solves conditions like below

<img width="1461" alt="image" src="https://github.com/antfu/eslint-config/assets/73387709/83a202ff-16b1-461d-89b6-3bf59e0a73ce">


FYI: https://github.com/antfu/install-pkg/pull/10

### Linked Issues

None

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
