### PR TITLE
feat!: rename `vue.vueVersion` to `vue.version`, and explain how to configure the Vue version in the document

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Auto fix for formatting (aimed to be used standalone **without** Prettier)
 - Sorted imports, dangling commas
 - Reasonable defaults, best practices, only one line of config
-- Designed to work with TypeScript, JSX, Vue out-of-box
+- Designed to work with TypeScript, JSX, Vue 2 & 3 out-of-box
 - Lints also for json, yaml, toml, markdown
 - Opinionated, but [very customizable](#customization)
 - [ESLint Flat config](https://eslint.org/docs/latest/use/configure/configuration-files-new), compose easily!
@@ -353,6 +353,19 @@ export default antfu({
       // ...
     },
   },
+})
+```
+
+### Vue version
+
+The default Vue version is 3, if you're using Vue 2:
+
+```js
+// eslint.config.js
+import antfu from '@antfu/eslint-config'
+
+export default antfu({
+  vue: { vueVersion: 2 },
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ The default Vue version is 3, if you're using Vue 2:
 import antfu from '@antfu/eslint-config'
 
 export default antfu({
-  vue: { vueVersion: 2 },
+  vue: { version: 2 },
 })
 ```
 

--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -10,7 +10,7 @@ export async function vue(
     files = [GLOB_VUE],
     overrides = {},
     stylistic = true,
-    vueVersion = 3,
+    version = 3,
   } = options
 
   const sfcBlocks = options.sfcBlocks === true
@@ -90,7 +90,7 @@ export async function vue(
       rules: {
         ...pluginVue.configs.base.rules as any,
 
-        ...vueVersion === 2
+        ...version === 2
           ? {
               ...pluginVue.configs.essential.rules as any,
               ...pluginVue.configs['strongly-recommended'].rules as any,

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ export interface OptionsVue extends OptionsOverrides {
    *
    * @default 3
    */
-  vueVersion?: 2 | 3
+  version?: 2 | 3
 }
 
 export type OptionsTypescript =


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

After debugging, I found that https://github.com/antfu/eslint-config/issues/443 is not a bug but rather missing documentation. I will submit two PRs (for two different solutions) to address this issue: one for automatic detection of the Vue version: https://github.com/antfu/eslint-config/pull/444, and another for documentation improvement (this one). Additionally, I've changed `vue.vueVersion` to `vue.version` for a more streamlined configuration. (It's a breaking change). You can choose the solution you think is appropriate to merge, thanks.

### Linked Issues

https://github.com/antfu/eslint-config/issues/443

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
