### PR TITLE
docs: add clarification on stylistic overrides and Svelte overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ export default antfu({
   stylistic: {
     indent: 2, // 4, or 'tab'
     quotes: 'single', // or 'double'
+    overrides: {
+      'style/brace-style': ['error', '1tbs', { allowSingleLine: true }],
+    },
   },
 
   // TypeScript and Vue are auto-detected, you can also explicitly enable them:
@@ -455,6 +458,26 @@ import antfu from '@antfu/eslint-config'
 export default antfu({
   svelte: true,
 })
+```
+
+For more control over which rules apply to your Svelte files, you apply overrides like this:
+ 
+```js
+// eslint.config.js
+import { antfu, svelte, typescript } from '@antfu/eslint-config'
+
+export default antfu(
+  {},
+  typescript({
+    componentExts: ['svelte'],
+  }),
+  svelte({
+    typescript: true,
+    overrides: {
+      'svelte/no-dom-manipulating': 'error',
+    },
+  }),
+)
 ```
 
 Running `npx eslint` should prompt you to install the required dependencies, otherwise, you can install them manually:


### PR DESCRIPTION
### Description

Adds a little instruction on how to apply overrides. These are things I had to figure out the hard way and hopefully can save the next guy some time by these tips.

Feel free to ignore these tips if they bloat the readme, but it's just what would have helped me out. :)

On the note of the stylistic overrides, I first used the stylistic function to provide overrides, but that bit me when `style/spaced-comment` was now also applied to `yaml` files instead of being overwritten by the yaml specific version. Thank goodness for the config inspector 😁.

![image](https://github.com/antfu/eslint-config/assets/7559478/1756d585-251c-4656-ac12-e3e15bb7dc6e)

On the note of Svelte, I personally don't think a simple `svelte: true` is usable at all. I have about 18 overrides. Some of them are preferences and nice things, but others are required just to make things work for Svelte, because there are some general rules that conflict. For example `no-self-assign` clashes with the way you must reassign an array to itself to get reactivity updates (this is going away in Svelte 5, but exists until then).