### PR TITLE
feat(svelte): add support for typing according to sveltejs/rfcs#38

### DIFF
--- a/src/configs/svelte.ts
+++ b/src/configs/svelte.ts
@@ -56,7 +56,7 @@ export async function svelte(
           caughtErrors: 'none',
           ignoreRestSiblings: true,
           vars: 'all',
-          varsIgnorePattern: '^\\$\\$Props$',
+          varsIgnorePattern: '^(\\$\\$Props$|\\$\\$Events$|\\$\\$Slots$)',
         }],
 
         'svelte/comment-directive': 'error',
@@ -83,7 +83,7 @@ export async function svelte(
 
         'unused-imports/no-unused-vars': [
           'error',
-          { args: 'after-used', argsIgnorePattern: '^_', vars: 'all', varsIgnorePattern: '^(_|\\$\\$Props$)' },
+          { args: 'after-used', argsIgnorePattern: '^_', vars: 'all', varsIgnorePattern: '^(_|\\$\\$Props$|\\$\\$Events$|\\$\\$Slots$)' },
         ],
 
         ...stylistic


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR attempts to add `$$Events` and `$$Slots` as known variables, similar to `$$Props` for the `svelte` plugin.
It follows from the [official RFC for typing Svelte components](https://github.com/sveltejs/rfcs/pull/38).

### Linked Issues

N/A

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

No tests failed on the local production build but AFAIK there don't seem to be any specific tests for Svelte files that have components with typing information.

