### PR TITLE
fix: tsconfigPath undefined

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -117,6 +117,9 @@ export function antfu(
     }
   }
 
+  const typescriptOptions = resolveSubOptions(options, 'typescript')
+  const tsconfigPath = 'tsconfigPath' in typescriptOptions ? typescriptOptions.tsconfigPath : undefined
+
   // Base configs
   configs.push(
     ignores(),
@@ -145,7 +148,7 @@ export function antfu(
 
   if (enableTypeScript) {
     configs.push(typescript({
-      ...resolveSubOptions(options, 'typescript'),
+      ...typescriptOptions,
       componentExts,
       overrides: getOverrides(options, 'typescript'),
     }))
@@ -182,14 +185,14 @@ export function antfu(
   if (enableReact) {
     configs.push(react({
       overrides: getOverrides(options, 'react'),
-      tsconfigPath: getOverrides(options, 'typescript').tsconfigPath,
+      tsconfigPath,
     }))
   }
 
   if (enableSolid) {
     configs.push(solid({
       overrides: getOverrides(options, 'solid'),
-      tsconfigPath: getOverrides(options, 'typescript').tsconfigPath,
+      tsconfigPath,
       typescript: !!enableTypeScript,
     }))
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR provides a fix to access to the `tsconfigPath` option in the factory function using resolveSubOptions instead of getOverrides.

### Linked Issues

fix https://github.com/antfu/eslint-config/issues/489

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
