### PR TITLE
fix: peer dependency version of svelte-eslint-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-svelte": ">=2.35.1",
     "prettier-plugin-astro": "^0.13.0",
     "prettier-plugin-slidev": "^1.0.5",
-    "svelte-eslint-parser": "^0.33.1"
+    "svelte-eslint-parser": ">=0.37.0"
   },
   "peerDependenciesMeta": {
     "@eslint-react/eslint-plugin": {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I think this fixes #503. I can't verify the fix locally because I don't know how to reproduce the original error locally when using `npm link`. Also tried [`pnpm link`](https://pnpm.io/cli/link) with [`strict-peer-dependencies=true`](https://pnpm.io/npmrc#strict-peer-dependencies), but `pnpm install eslint-plugin-svelte` always exits successfully.

Anyways this PR:

1. Loosens the peer dep range. It was `~X.X.X` and now it's `>=X.X.X`
1. I also updated the peer dep version to the latest one. I figured since we're using the latest version so should our consumers.

Either way, since the change is very minimal I figured I'd just send the PR and someone with more knowledge than me can maybe eyeball it. Feel free to close this PR if it doesn't look right.

### Linked Issues

#503

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
