### PR TITLE
feat(typescript): add `ts/switch-exhaustiveness-check` rule

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -49,6 +49,7 @@ export async function typescript(
     'ts/restrict-plus-operands': 'error',
     'ts/restrict-template-expressions': 'error',
     'ts/strict-boolean-expressions': 'error',
+    'ts/switch-exhaustiveness-check': 'error',
     'ts/unbound-method': 'error',
   }
 


### PR DESCRIPTION
This commit adds the 'ts/switch-exhaustiveness-check' rule to the TypeScript configuration. This rule helps ensure that all possible cases in a switch statement are handled.
https://typescript-eslint.io/rules/switch-exhaustiveness-check
Without this PR, it causes an error like below:

```
Error: Error while loading rule 'ts/switch-exhaustiveness-check': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.
Parser: undefined
Note: detected a parser other than @typescript-eslint/parser. Make sure the parser is configured to forward "parserOptions.project" to @typescript-eslint/parser.```
