### PR TITLE
feat(typescript): add 'ts/return-await' rule

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -48,6 +48,7 @@ export async function typescript(
     'ts/no-unsafe-return': 'error',
     'ts/restrict-plus-operands': 'error',
     'ts/restrict-template-expressions': 'error',
+    'ts/return-await': 'error',
     'ts/strict-boolean-expressions': 'error',
     'ts/unbound-method': 'error',
   }


### PR DESCRIPTION
This commit adds the 'ts/return-await' rule to the TypeScript configuration. This rule enforces that 'return await' is used in async functions.

https://typescript-eslint.io/rules/return-await

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
