### PR TITLE
feat(typescript): add 'ts/promise-function-async' to type aware rule

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -46,6 +46,7 @@ export async function typescript(
     'ts/no-unsafe-call': 'error',
     'ts/no-unsafe-member-access': 'error',
     'ts/no-unsafe-return': 'error',
+    'ts/promise-function-async': 'error',
     'ts/restrict-plus-operands': 'error',
     'ts/restrict-template-expressions': 'error',
     'ts/strict-boolean-expressions': 'error',


### PR DESCRIPTION
This commit introduces a new rule 'ts/promise-function-async' to the TypeScript configuration. This rule enforces the use of async keyword when a function returns a Promise.

https://typescript-eslint.io/rules/promise-function-async

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
