### PR TITLE
Use 'eslint.useFlatConfig' instead of 'eslint.experimental.useFlatConfig'

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Add the following settings to your `.vscode/settings.json`:
 {
   // Enable the ESlint flat config support
   // (remove this if your ESLint extension above v3.0.5)
-  "eslint.experimental.useFlatConfig": true,
+  "eslint.useFlatConfig": true,
 
   // Disable the default formatter, use eslint instead
   "prettier.enable": false,


### PR DESCRIPTION
Replace 'eslint.experimental.useFlatConfig' with 'eslint.useFlatConfig' for ESLint versions greater than or equal to 8.57.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
