### PR TITLE
chore: replace react default files glob patterns `[GLOB_JS, GLOB_JSX, GLOB_TS, GLOB_TSX]` to `[GLOB_SRC]`

### DIFF
--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -1,7 +1,7 @@
 import { isPackageExists } from 'local-pkg'
 import { ensurePackages, interopDefault, toArray } from '../utils'
 import type { OptionsFiles, OptionsOverrides, OptionsTypeScriptWithTypes, TypedFlatConfigItem } from '../types'
-import { GLOB_JS, GLOB_JSX, GLOB_TS, GLOB_TSX } from '../globs'
+import { GLOB_SRC } from '../globs'
 
 // react refresh
 const ReactRefreshAllowConstantExportPackages = [
@@ -21,7 +21,7 @@ export async function react(
   options: OptionsTypeScriptWithTypes & OptionsOverrides & OptionsFiles = {},
 ): Promise<TypedFlatConfigItem[]> {
   const {
-    files = [GLOB_JS, GLOB_JSX, GLOB_TS, GLOB_TSX],
+    files = [GLOB_SRC],
     overrides = {},
   } = options
 


### PR DESCRIPTION
### Description

This PR replaces the react config default files individual glob patterns (`[GLOB_JS, GLOB_JSX, GLOB_TS, GLOB_TSX]`) with a single unified pattern (`[GLOB_SRC]`). The new pattern `'**/*.?([cm])[jt]s?(x)'` covers all the specific cases previously handled by the separate patterns, reducing redundancy and simplifying the configuration.
