### PR TITLE
fix: Add `.svelte-kit` to ignored paths

### DIFF
--- a/src/globs.ts
+++ b/src/globs.ts
@@ -70,6 +70,7 @@ export const GLOB_EXCLUDE = [
   '**/.vitepress/cache',
   '**/.nuxt',
   '**/.next',
+  '**/.svelte-kit',
   '**/.vercel',
   '**/.changeset',
   '**/.idea',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

With the out-of-the box config and svelte plugin enabled, files in the auto-generated `.svelte-kit` directory are linted.

This simple PR adds `'**/.svelte-kit'` to `GLOB_EXCLUDE`.

### Linked Issues

### Additional context
