### PR TITLE
fix(typescript): remove string[] from tsconfigPath as not supported in v8

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,7 @@ export interface OptionsTypeScriptWithTypes {
    * When this options is provided, type aware rules will be enabled.
    * @see https://typescript-eslint.io/linting/typed-linting/
    */
-  tsconfigPath?: string | string[]
+  tsconfigPath?: string
 }
 
 export interface OptionsHasTypeScript {


### PR DESCRIPTION
### Description

Follow up PR from https://github.com/antfu/eslint-config/pull/541, since`projectService.defaultProject` not support array the type should not allow user to be able to pass an array of string.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
