### PR TITLE
fix: enable `eslint-config-flat-gitignore` even if `.gitignore` is not in cwd

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -114,8 +114,7 @@ export function antfu(
       configs.push(interopDefault(import('eslint-config-flat-gitignore')).then(r => [r(enableGitignore)]))
     }
     else {
-      if (fs.existsSync('.gitignore'))
-        configs.push(interopDefault(import('eslint-config-flat-gitignore')).then(r => [r()]))
+      configs.push(interopDefault(import('eslint-config-flat-gitignore')).then(r => [r({ strict: false })]))
     }
   }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,5 +1,4 @@
 import process from 'node:process'
-import fs from 'node:fs'
 import { isPackageExists } from 'local-pkg'
 import { FlatConfigComposer } from 'eslint-flat-config-utils'
 import type { Linter } from 'eslint'


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In a monorepo, you may only have a single `.gitignore` at the root of the repo, but run the eslint from within package subdirectories. In this scenario, `@antfu/eslint-config` doesn't currently add gitignore entries to the eslint ignores.

This PR enables `eslint-config-flat-gitignore` even if a `.gitignore` is not present in the current directory, as it has `find-up-simple` to look for a `.gitignore` in a higher directory.

I've set `{ strict: false }` so that it doesn't error if it can't find a `.gitignore` file at all.

### Linked Issues

Fixes #544

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
