### PR TITLE
fix: remove deprecated 'ts/prefer-ts-expect-error' rule

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -145,7 +145,6 @@ export async function typescript(
         'ts/no-use-before-define': ['error', { classes: false, functions: false, variables: true }],
         'ts/no-useless-constructor': 'off',
         'ts/no-wrapper-object-types': 'error',
-        'ts/prefer-ts-expect-error': 'error',
         'ts/triple-slash-reference': 'off',
         'ts/unified-signatures': 'off',
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When I was reviewing the [typescript-eslint](https://typescript-eslint.io/rules/prefer-ts-expect-error/) documentation, I came across the following statement :

“This rule has been deprecated in favor of [@typescript-eslint/ban-ts-comment](https://typescript-eslint.io/rules/ban-ts-comment). This rule (@typescript-eslint/prefer-ts-expect-error) will be removed in a future major version of typescript-eslint.”

### Additional context

![截圖 2024-07-18 下午1 53 06](https://github.com/user-attachments/assets/7b94fa46-42da-446f-bf73-88967f14dc98)


