### PR TITLE
fix: default prettier `printWidth: 120` not work as expected

### DIFF
--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -43,6 +43,7 @@ export async function formatters(
   const prettierOptions: VendoredPrettierOptions = Object.assign(
     {
       endOfLine: 'auto',
+      printWidth: 120,
       semi,
       singleQuote: quotes === 'single',
       tabWidth: typeof indent === 'number' ? indent : 2,
@@ -197,7 +198,6 @@ export async function formatters(
           'error',
           formater === 'prettier'
             ? {
-                printWidth: 120,
                 ...prettierOptions,
                 embeddedLanguageFormatting: 'off',
                 parser: 'markdown',
@@ -221,7 +221,6 @@ export async function formatters(
           'format/prettier': [
             'error',
             {
-              printWidth: 120,
               ...prettierOptions,
               embeddedLanguageFormatting: 'off',
               parser: 'slidev',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Default prettier `printWidth: 120` not work for `css` as pointed here:
https://github.com/antfu/eslint-config/blob/1215d9fd98e4b6fee57453312a22c2340c91f085/src/vender/prettier-types.ts#L7-L12

`printWidth: 120` is only set for `markdown` / `slidev`, others will fallback to use prettier's default `80`.

In the following reproduction project: 

[stackblitz.com/~/github.com/HADB/eslint-config-prettier-printWidth-bug-reproduction?file=assets/styles.css](https://stackblitz.com/~/github.com/HADB/eslint-config-prettier-printWidth-bug-reproduction?file=assets/styles.css)

```css
body {
  font-family: 'LXGW WenKai GB', 'LXGW WenKai', '仿宋', 'FangSong', 'STFangsong', 'serif';
}
```
will be formatted to:
```css
body {
  font-family: 'LXGW WenKai GB', 'LXGW WenKai', '仿宋', 'FangSong', 'STFangsong',
    'serif';
}
```

### Linked Issues

Fix #572

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
