### PR TITLE
fix: check packages existence in local scope

### DIFF
--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -1,7 +1,7 @@
 import { isPackageExists } from 'local-pkg'
 import { GLOB_ASTRO, GLOB_ASTRO_TS, GLOB_CSS, GLOB_GRAPHQL, GLOB_HTML, GLOB_LESS, GLOB_MARKDOWN, GLOB_POSTCSS, GLOB_SCSS, GLOB_XML } from '../globs'
 import type { VendoredPrettierOptions } from '../vender/prettier-types'
-import { ensurePackages, interopDefault, parserPlain } from '../utils'
+import { ensurePackages, interopDefault, isPackageInScope, parserPlain } from '../utils'
 import type { OptionsFormatters, StylisticConfig, TypedFlatConfigItem } from '../types'
 import { StylisticConfigDefaults } from './stylistic'
 
@@ -11,13 +11,13 @@ export async function formatters(
 ): Promise<TypedFlatConfigItem[]> {
   if (options === true) {
     options = {
-      astro: isPackageExists('prettier-plugin-astro'),
+      astro: isPackageInScope('prettier-plugin-astro'),
       css: true,
       graphql: true,
       html: true,
       markdown: true,
       slidev: isPackageExists('@slidev/cli'),
-      xml: isPackageExists('@prettier/plugin-xml'),
+      xml: isPackageInScope('@prettier/plugin-xml'),
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,11 +107,19 @@ export async function interopDefault<T>(m: Awaitable<T>): Promise<T extends { de
   return (resolved as any).default || resolved
 }
 
+const scopeUrl = String(new URL('.', import.meta.url))
+
+export function isPackageInScope(name: string): boolean {
+  return isPackageExists(name, { paths: [scopeUrl] })
+}
+
+const isCwdInScope = isPackageExists('@antfu/eslint-config')
+
 export async function ensurePackages(packages: (string | undefined)[]): Promise<void> {
-  if (process.env.CI || process.stdout.isTTY === false)
+  if (process.env.CI || process.stdout.isTTY === false || isCwdInScope === false)
     return
 
-  const nonExistingPackages = packages.filter(i => i && !isPackageExists(i)) as string[]
+  const nonExistingPackages = packages.filter(i => i && !isPackageInScope(i)) as string[]
   if (nonExistingPackages.length === 0)
     return
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,10 @@
 import process from 'node:process'
+import { fileURLToPath } from 'node:url'
 import { isPackageExists } from 'local-pkg'
 import type { Awaitable, TypedFlatConfigItem } from './types'
+
+const scopeUrl = fileURLToPath(new URL('.', import.meta.url))
+const isCwdInScope = isPackageExists('@antfu/eslint-config')
 
 export const parserPlain = {
   meta: {
@@ -107,13 +111,9 @@ export async function interopDefault<T>(m: Awaitable<T>): Promise<T extends { de
   return (resolved as any).default || resolved
 }
 
-const scopeUrl = String(new URL('.', import.meta.url))
-
 export function isPackageInScope(name: string): boolean {
   return isPackageExists(name, { paths: [scopeUrl] })
 }
-
-const isCwdInScope = isPackageExists('@antfu/eslint-config')
 
 export async function ensurePackages(packages: (string | undefined)[]): Promise<void> {
   if (process.env.CI || process.stdout.isTTY === false || isCwdInScope === false)


### PR DESCRIPTION
### Description

- Use explicit scope path for existence checks of ESLint/Prettier plugin deps
- Skip installation of missing packages if current working directory is not in scope of `@antfu/eslint-config`

### Linked Issues

Fixes #581 

### Additional context

- The existence check for packages that aren't directly used, but just control the config (e.g. `typescript`) is not changed, as for those it makes sense to look in current working directory.
