### PR TITLE
feat: support prettierConfigs with internal default options

### DIFF
--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -53,7 +53,7 @@ export async function formatters(
     options.prettierOptions || {},
   )
 
-  const prettierXmlOptions = {
+  const prettierXmlOptions: VendoredPrettierOptions = {
     xmlQuoteAttributes: 'double',
     xmlSelfClosingSpace: true,
     xmlSortAttributesByKey: false,
@@ -286,6 +286,16 @@ export async function formatters(
           },
         ],
       },
+    })
+  }
+
+  if (options.prettierConfigs) {
+    const prettierConfigs = options.prettierConfigs({
+      defaultOptions: prettierOptions,
+      defaultXmlOptions: prettierXmlOptions,
+    })
+    prettierConfigs.forEach((item) => {
+      configs.push(item)
     })
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,11 @@ export type OptionsTypescript =
   (OptionsTypeScriptWithTypes & OptionsOverrides)
   | (OptionsTypeScriptParserOptions & OptionsOverrides)
 
+export interface PrettierConfigsOptions {
+  defaultOptions: VendoredPrettierOptions
+  defaultXmlOptions: VendoredPrettierOptions
+}
+
 export interface OptionsFormatters {
   /**
    * Enable formatting support for CSS, Less, Sass, and SCSS.
@@ -92,6 +97,11 @@ export interface OptionsFormatters {
    * By default it's controlled by our own config.
    */
   prettierOptions?: VendoredPrettierOptions
+
+  /**
+   * Custom configs let you have different configuration for certain file extensions and specific files.
+   */
+  prettierConfigs?: (options: PrettierConfigsOptions) => TypedFlatConfigItem[]
 
   /**
    * Custom options for dprint.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`prettierConfigs` with internal runtime default options makes users customize code format easy with the consistent format style.

For examples:
- I customize formatting SVG with html parser before
- I also want to allow users to format `GLOB_SRC` with prettier rather than stylistic
- Others possible code formatting by prettier...

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
