### PR TITLE
fix: remove redundant statements from `no-restricted-syntax`

### DIFF
--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -117,9 +117,6 @@ export async function javascript(
         ],
         'no-restricted-syntax': [
           'error',
-          'DebuggerStatement',
-          'LabeledStatement',
-          'WithStatement',
           'TSEnumDeclaration[const=true]',
           'TSExportAssignment',
         ],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I wanted to enable `no-debugger` when `isEditorEnv`, but apparently there are *two* rules that mess with it

![image](https://github.com/user-attachments/assets/31cf39a3-df23-4736-9cc7-38911b535aa9)

`no-debugger`, `no-with` and `no-labels` are already present, so the `no-restricted-syntax` shouldn't cover them

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
`vue/no-restricted-syntax` should be kept as it works in `<template>` and `no-debugger`, `no-with` and `no-labels` don't