### PR TITLE
feat: merge prettier plugins with options

### DIFF
--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -1,11 +1,25 @@
 import type { OptionsFormatters, StylisticConfig, TypedFlatConfigItem } from '../types'
-import type { VendoredPrettierOptions } from '../vender/prettier-types'
+import type { VendoredPrettierOptions, VendoredPrettierRuleOptions } from '../vender/prettier-types'
 
 import { isPackageExists } from 'local-pkg'
 import { GLOB_ASTRO, GLOB_ASTRO_TS, GLOB_CSS, GLOB_GRAPHQL, GLOB_HTML, GLOB_LESS, GLOB_MARKDOWN, GLOB_POSTCSS, GLOB_SCSS, GLOB_SVG, GLOB_XML } from '../globs'
 
 import { ensurePackages, interopDefault, isPackageInScope, parserPlain } from '../utils'
 import { StylisticConfigDefaults } from './stylistic'
+
+function mergePrettierOptions(
+  options: VendoredPrettierOptions,
+  overrides: VendoredPrettierRuleOptions = {},
+): VendoredPrettierRuleOptions {
+  return {
+    ...options,
+    ...overrides,
+    plugins: [
+      ...(overrides.plugins || []),
+      ...(options.plugins || []),
+    ],
+  }
+}
 
 export async function formatters(
   options: OptionsFormatters | true = {},
@@ -57,7 +71,7 @@ export async function formatters(
     options.prettierOptions || {},
   )
 
-  const prettierXmlOptions = {
+  const prettierXmlOptions: VendoredPrettierOptions = {
     xmlQuoteAttributes: 'double',
     xmlSelfClosingSpace: true,
     xmlSortAttributesByKey: false,
@@ -95,10 +109,9 @@ export async function formatters(
         rules: {
           'format/prettier': [
             'error',
-            {
-              ...prettierOptions,
+            mergePrettierOptions(prettierOptions, {
               parser: 'css',
-            },
+            }),
           ],
         },
       },
@@ -111,10 +124,9 @@ export async function formatters(
         rules: {
           'format/prettier': [
             'error',
-            {
-              ...prettierOptions,
+            mergePrettierOptions(prettierOptions, {
               parser: 'scss',
-            },
+            }),
           ],
         },
       },
@@ -127,10 +139,9 @@ export async function formatters(
         rules: {
           'format/prettier': [
             'error',
-            {
-              ...prettierOptions,
+            mergePrettierOptions(prettierOptions, {
               parser: 'less',
-            },
+            }),
           ],
         },
       },
@@ -147,10 +158,9 @@ export async function formatters(
       rules: {
         'format/prettier': [
           'error',
-          {
-            ...prettierOptions,
+          mergePrettierOptions(prettierOptions, {
             parser: 'html',
-          },
+          }),
         ],
       },
     })
@@ -166,14 +176,12 @@ export async function formatters(
       rules: {
         'format/prettier': [
           'error',
-          {
-            ...prettierXmlOptions,
-            ...prettierOptions,
+          mergePrettierOptions({ ...prettierXmlOptions, ...prettierOptions }, {
             parser: 'xml',
             plugins: [
               '@prettier/plugin-xml',
             ],
-          },
+          }),
         ],
       },
     })
@@ -188,14 +196,12 @@ export async function formatters(
       rules: {
         'format/prettier': [
           'error',
-          {
-            ...prettierXmlOptions,
-            ...prettierOptions,
+          mergePrettierOptions({ ...prettierXmlOptions, ...prettierOptions }, {
             parser: 'xml',
             plugins: [
               '@prettier/plugin-xml',
             ],
-          },
+          }),
         ],
       },
     })
@@ -223,11 +229,10 @@ export async function formatters(
         [`format/${formater}`]: [
           'error',
           formater === 'prettier'
-            ? {
-                ...prettierOptions,
-                embeddedLanguageFormatting: 'off',
-                parser: 'markdown',
-              }
+            ? mergePrettierOptions(prettierOptions, {
+              embeddedLanguageFormatting: 'off',
+              parser: 'markdown',
+            })
             : {
                 ...dprintOptions,
                 language: 'markdown',
@@ -246,14 +251,13 @@ export async function formatters(
         rules: {
           'format/prettier': [
             'error',
-            {
-              ...prettierOptions,
+            mergePrettierOptions(prettierOptions, {
               embeddedLanguageFormatting: 'off',
               parser: 'slidev',
               plugins: [
                 'prettier-plugin-slidev',
               ],
-            },
+            }),
           ],
         },
       })
@@ -270,13 +274,12 @@ export async function formatters(
       rules: {
         'format/prettier': [
           'error',
-          {
-            ...prettierOptions,
+          mergePrettierOptions(prettierOptions, {
             parser: 'astro',
             plugins: [
               'prettier-plugin-astro',
             ],
-          },
+          }),
         ],
       },
     })
@@ -306,10 +309,9 @@ export async function formatters(
       rules: {
         'format/prettier': [
           'error',
-          {
-            ...prettierOptions,
+          mergePrettierOptions(prettierOptions, {
             parser: 'graphql',
-          },
+          }),
         ],
       },
     })

--- a/src/vender/prettier-types.ts
+++ b/src/vender/prettier-types.ts
@@ -4,6 +4,11 @@
 
 export type VendoredPrettierOptions = Partial<VendoredPrettierOptionsRequired>
 
+export type VendoredPrettierRuleOptions = VendoredPrettierOptions & {
+  parser?: BuiltInParserName | ExternalParserName
+  [k: string]: unknown | undefined
+}
+
 export interface VendoredPrettierOptionsRequired {
   /**
    * Specify the line length that the printer will wrap on.
@@ -145,6 +150,8 @@ export type BuiltInParserName =
   | 'vue'
   | 'xml'
   | 'yaml'
+
+export type ExternalParserName = 'slidev' | 'astro'
 
 // This utility is here to handle the case where you have an explicit union
 // between string literals and the generic string type. It would normally


### PR DESCRIPTION
### Description

Merges plugins list for prettier, allows adding more prettier plugins via `prettierOptions`

Example
```javascript
antfu({
  formatters: {
    astro: true,
    prettierOptions: {
      plugins: ['prettier-plugin-tailwindcss'],
    },
  },
})
```

### Linked Issues

Closes https://github.com/antfu/eslint-config/issues/613
