### PR TITLE
Add install command to cli outro

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -116,5 +116,5 @@ export async function run(options: CliRunOptions = {}): Promise<void> {
   await updateVscodeSettings(result)
 
   p.log.success(c.green(`Setup completed`))
-  p.outro(`Now you can update the dependencies and run ${c.blue('eslint . --fix')}\n`)
+  p.outro(`Now you can update the dependencies by run ${c.blue('pnpm install')} and run ${c.blue('eslint . --fix')}\n`)
 }


### PR DESCRIPTION
### Description

When using the starter wizard CLI to install `@antfu/eslint-config`, I noticed that the script adds `@antfu/eslint-config` to the package.json, but I forgot to run the command to install dependencies before starting my project.

This oversight can cause confusion for users who might skip this step.

Therefore, I’ve added an install command to the CLI’s outro description to remind users to install dependencies after running the CLI. This change makes it clearer and ensures users are aware they need to install dependencies before starting their work.

### Additional context
**Screenshot:**
<img width="899" alt="image" src="https://github.com/user-attachments/assets/6e35de32-4cfa-4d98-8123-805b7204a840">

---

If you have any feedback or suggestions, please let me know.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
