### PR TITLE
fix: disable `antfu/no-top-level-await` for Astro

### DIFF
--- a/src/configs/astro.ts
+++ b/src/configs/astro.ts
@@ -55,6 +55,10 @@ export async function astro(
         'astro/semi': 'off',
         'astro/valid-compile': 'error',
 
+        // Astro uses top level await for e.g. data fetching
+        // https://docs.astro.build/en/guides/data-fetching/#fetch-in-astro
+        'antfu/no-top-level-await': 'off',
+
         ...stylistic
           ? {
               'style/indent': 'off',

--- a/src/configs/astro.ts
+++ b/src/configs/astro.ts
@@ -43,6 +43,10 @@ export async function astro(
       name: 'antfu/astro/rules',
       processor: 'astro/client-side-ts',
       rules: {
+        // Astro uses top level await for e.g. data fetching
+        // https://docs.astro.build/en/guides/data-fetching/#fetch-in-astro
+        'antfu/no-top-level-await': 'off',
+
         // use recommended rules
         'astro/missing-client-only-directive-value': 'error',
         'astro/no-conflict-set-directives': 'error',
@@ -54,10 +58,6 @@ export async function astro(
         'astro/no-unused-define-vars-in-style': 'error',
         'astro/semi': 'off',
         'astro/valid-compile': 'error',
-
-        // Astro uses top level await for e.g. data fetching
-        // https://docs.astro.build/en/guides/data-fetching/#fetch-in-astro
-        'antfu/no-top-level-await': 'off',
 
         ...stylistic
           ? {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

[Astro uses top level await a lot](https://docs.astro.build/en/guides/data-fetching/#fetch-in-astro):

> Take advantage of top-level await inside of your Astro component script.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
