### PR TITLE
feat: support React Router 7 in react-refresh rules

### DIFF
--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -15,6 +15,12 @@ const RemixPackages = [
   '@remix-run/serve',
   '@remix-run/dev',
 ]
+const ReactRouterPackages = [
+  '@react-router/node',
+  '@react-router/react',
+  '@react-router/serve',
+  '@react-router/dev',
+]
 const NextJsPackages = [
   'next',
 ]
@@ -57,6 +63,7 @@ export async function react(
 
   const isAllowConstantExport = ReactRefreshAllowConstantExportPackages.some(i => isPackageExists(i))
   const isUsingRemix = RemixPackages.some(i => isPackageExists(i))
+  const isUsingReactRouter = ReactRouterPackages.some(i => isPackageExists(i))
   const isUsingNext = NextJsPackages.some(i => isPackageExists(i))
 
   const plugins = pluginReact.configs.all.plugins
@@ -125,7 +132,7 @@ export async function react(
                     'generateViewport',
                   ]
                 : []),
-              ...(isUsingRemix
+              ...(isUsingRemix || isUsingReactRouter
                 ? [
                     'meta',
                     'links',


### PR DESCRIPTION
### Description

The react-refresh plugin configuration contains a few rules specific to NextJS and Remix, eliminating a number of unnecessary warnings.

React Router 7 introduces major updates that render `@remix-run/*` imports obsolete. Remix applications now use `@react-router/*` imports instead.

So to allow specific react-refresh rules also working with new React Router 7 apps, we need to detect `@react-router` imports too.