### PR TITLE
fix(unicorn): move `no-instanceof-array` to `no-instanceof-builtins`

### DIFF
--- a/src/configs/unicorn.ts
+++ b/src/configs/unicorn.ts
@@ -11,13 +11,13 @@ export async function unicorn(options: OptionsUnicorn = {}): Promise<TypedFlatCo
       },
       rules: {
         ...(options.allRecommended
-          ? pluginUnicorn.configs['flat/recommended'].rules
+          ? pluginUnicorn.configs.recommended.rules
           : {
               'unicorn/consistent-empty-array-spread': 'error',
               'unicorn/error-message': 'error',
               'unicorn/escape-case': 'error',
               'unicorn/new-for-builtins': 'error',
-              'unicorn/no-instanceof-array': 'error',
+              'unicorn/no-instanceof-builtins': 'error',
               'unicorn/no-new-array': 'error',
               'unicorn/no-new-buffer': 'error',
               'unicorn/number-literal-case': 'error',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- `flat/recommended` was deprecated. Use `recommended` directly.
- [`no-instanceof-array`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v57.0.0/docs/deprecated-rules.md#no-instanceof-array) was deprecated. They recommend replacing it with [`no-instanceof-builtins`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v57.0.0/docs/rules/no-instanceof-builtins.md)

### Linked Issues


### Additional context

https://github.com/sindresorhus/eslint-plugin-unicorn/releases/tag/v57.0.0
https://github.com/sindresorhus/eslint-plugin-unicorn/pull/2534

<!-- e.g. is there anything you'd like reviewers to focus on? -->
