### PR TITLE
feat: support rule type augmentations without eslint-typegen

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ import type { VendoredPrettierOptions } from './vender/prettier-types'
 
 export type Awaitable<T> = T | Promise<T>
 
-export type Rules = RuleOptions
+export interface Rules extends RuleOptions {}
 
 export type { ConfigNames }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR adds support for extending the `RuleOptions` vis ts module augmentation in userland. This can be useful, especially for library authors, when building on top of `@antfu/eslint-config` with custom plugins/configs/rules/etc.

No need for generating types via `eslint-typegen` 👍 

Example in `company/recommended/index.d.ts`:
```ts
declare module '@antfu/eslint-config' {
  export interface Rules {
    'company/custom-rule': Linter.RuleEntry<[RuleArgs]>
  }
}
```

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
