### PR TITLE
feat: allow `unicorn` and `svelte` to overrides rules

### DIFF
--- a/src/configs/unicorn.ts
+++ b/src/configs/unicorn.ts
@@ -3,6 +3,10 @@ import type { OptionsUnicorn, TypedFlatConfigItem } from '../types'
 import { pluginUnicorn } from '../plugins'
 
 export async function unicorn(options: OptionsUnicorn = {}): Promise<TypedFlatConfigItem[]> {
+  const {
+    allRecommended = false,
+    overrides = {},
+  } = options
   return [
     {
       name: 'antfu/unicorn/rules',
@@ -10,7 +14,7 @@ export async function unicorn(options: OptionsUnicorn = {}): Promise<TypedFlatCo
         unicorn: pluginUnicorn,
       },
       rules: {
-        ...(options.allRecommended
+        ...(allRecommended
           ? pluginUnicorn.configs.recommended.rules
           : {
               'unicorn/consistent-empty-array-spread': 'error',
@@ -29,6 +33,7 @@ export async function unicorn(options: OptionsUnicorn = {}): Promise<TypedFlatCo
               'unicorn/prefer-type-error': 'error',
               'unicorn/throw-new-error': 'error',
             }),
+        ...overrides,
       },
     },
   ]

--- a/src/types.ts
+++ b/src/types.ts
@@ -386,7 +386,7 @@ export interface OptionsConfig extends OptionsComponentExts, OptionsProjectType 
    *
    * @default false
    */
-  svelte?: boolean
+  svelte?: boolean | OptionsOverrides
 
   /**
    * Enable unocss rules.

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,7 +142,7 @@ export interface OptionsComponentExts {
   componentExts?: string[]
 }
 
-export interface OptionsUnicorn {
+export interface OptionsUnicorn extends OptionsOverrides {
   /**
    * Include all rules recommended by `eslint-plugin-unicorn`, instead of only ones picked by Anthony.
    *


### PR DESCRIPTION
### Description
I just found that it is not able to override `unicorn`'s rules with
```js
antfu({
  unicorn: {
    overrides: {
    }
  }
}
```

On the other hand, TS also report type error if users try to override `svelte`'s rules.

And I am trying to fix them