### PR TITLE
fix(sort): add "imports" key before "exports" for pkg.json

### DIFF
--- a/src/configs/sort.ts
+++ b/src/configs/sort.ts
@@ -40,6 +40,7 @@ export async function sortPackageJson(): Promise<TypedFlatConfigItem[]> {
               'keywords',
               'categories',
               'sideEffects',
+              'imports',
               'exports',
               'main',
               'module',


### PR DESCRIPTION
### Description

Hello,

This PR add the keyword `imports` in the `jsonc/sort-keys` applied on `package.json` files.
Keywords already exist for `exports` or `main` but not the `imports` for using [Node subpath imports](https://nodejs.org/docs/latest-v22.x/api/packages.html#subpath-imports).

Usually, I set my "imports" before the "exports" or "main", because from my pov it "affects" the code of a package internally, before the exports are used by another package (or will be parsed by a bundler).

Example:
```json
{
  "name": "fake-name",
  "type": "module",
  "version": "0.0.1",
  "private": true,
  "imports": {
    "#*": "./src/*"
  },
  "exports": {
    ".": "./index.ts"
  },
  ...
}
```


Thanks,