### PR TITLE
fix: don't use deprecated option

### DIFF
--- a/src/configs/jsonc.ts
+++ b/src/configs/jsonc.ts
@@ -74,7 +74,7 @@ export async function jsonc(
               'jsonc/key-spacing': ['error', { afterColon: true, beforeColon: false }],
               'jsonc/object-curly-newline': ['error', { consistent: true, multiline: true }],
               'jsonc/object-curly-spacing': ['error', 'always'],
-              'jsonc/object-property-newline': ['error', { allowMultiplePropertiesPerLine: true }],
+              'jsonc/object-property-newline': ['error', { allowAllPropertiesOnSameLine: true }],
               'jsonc/quote-props': 'error',
               'jsonc/quotes': 'error',
             }

--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -193,7 +193,7 @@ export async function vue(
               'vue/keyword-spacing': ['error', { after: true, before: true }],
               'vue/object-curly-newline': 'off',
               'vue/object-curly-spacing': ['error', 'always'],
-              'vue/object-property-newline': ['error', { allowMultiplePropertiesPerLine: true }],
+              'vue/object-property-newline': ['error', { allowAllPropertiesOnSameLine: true }],
               'vue/operator-linebreak': ['error', 'before'],
               'vue/padding-line-between-blocks': ['error', 'always'],
               'vue/quote-props': ['error', 'consistent-as-needed'],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`allowMultiplePropertiesPerLine` has been deprecated, use `allowAllPropertiesOnSameLine` instead.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context
- https://github.com/ota-meshi/eslint-plugin-jsonc/blob/master/lib/rules/object-property-newline.ts
<!-- e.g. is there anything you'd like reviewers to focus on? -->
