### PR TITLE
fix: update GLOB_SVELTE to include .js/.ts extensions

### DIFF
--- a/src/globs.ts
+++ b/src/globs.ts
@@ -19,7 +19,7 @@ export const GLOB_JSONC = '**/*.jsonc'
 
 export const GLOB_MARKDOWN = '**/*.md'
 export const GLOB_MARKDOWN_IN_MARKDOWN = '**/*.md/*.md'
-export const GLOB_SVELTE = '**/*.svelte'
+export const GLOB_SVELTE = '**/*.svelte?(.{js,ts})'
 export const GLOB_VUE = '**/*.vue'
 export const GLOB_YAML = '**/*.y?(a)ml'
 export const GLOB_TOML = '**/*.toml'


### PR DESCRIPTION
### Description

This PR adds support for Svelte 5 file extensions by updating the `GLOB_SVELTE` pattern to include `.svelte.js` and `.svelte.ts` files.

**Changes:**
- Updated `GLOB_SVELTE` from `'**/*.svelte'` to `'**/*.svelte?(.{js,ts})'`
- Now matches `.svelte`, `.svelte.js`, and `.svelte.ts` files

**Why this change is needed:**
Svelte 5 introduces support for `.svelte.js` and `.svelte.ts` files as documented in the [official Svelte 5 documentation](https://svelte.dev/docs/svelte/svelte-js-files). These files allow developers to write Svelte components using JavaScript/TypeScript syntax while still being processed as Svelte components.

Without this change, the current glob pattern would miss these new file types, causing them to be ignored during processing.

### Additional context
The new glob pattern uses optional matching `?(.{js,ts})` which means:
- `**/*.svelte` - matches traditional .svelte files
- `**/*.svelte.js` - matches new Svelte 5 JavaScript files  
- `**/*.svelte.ts` - matches new Svelte 5 TypeScript files