### PR TITLE
fix: update `TypedFlatConfigItem` to provide rules auto-completion

### DIFF
--- a/src/cli/constants-generated.ts
+++ b/src/cli/constants-generated.ts
@@ -1,6 +1,6 @@
 export const versionsMap = {
   "@eslint-react/eslint-plugin": "^1.52.3",
-  "@next/eslint-plugin-next": "^15.4.0-canary.115",
+  "@next/eslint-plugin-next": "^15.4.3",
   "@unocss/eslint-plugin": "^66.3.3",
   "astro-eslint-parser": "^1.2.2",
   "eslint": "^9.31.0",

--- a/src/configs/nextjs.ts
+++ b/src/configs/nextjs.ts
@@ -41,6 +41,7 @@ export async function nextjs(
         },
         sourceType: 'module',
       },
+      name: 'antfu/nextjs/rules',
       rules: {
         ...normalizeRules(pluginNextJS.configs.recommended.rules),
         ...normalizeRules(pluginNextJS.configs['core-web-vitals'].rules),

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,23 +8,29 @@ import type { VendoredPrettierOptions } from './vender/prettier-types'
 
 export type Awaitable<T> = T | Promise<T>
 
-export interface Rules extends RuleOptions {}
+export type Rules = Record<string, Linter.RuleEntry<any> | undefined> & RuleOptions
 
 export type { ConfigNames }
 
-export type TypedFlatConfigItem = Omit<Linter.Config<Linter.RulesRecord & Rules>, 'plugins' | 'rules'> & {
-  // Relax plugins type limitation, as most of the plugins did not have correct type info yet.
+/**
+ * An updated version of ESLint's `Linter.Config`, which provides autocompletion
+ * for `rules` and relaxes type limitations for `plugins` and `rules`, because
+ * many plugins still lack proper type definitions.
+ */
+export type TypedFlatConfigItem = Omit<Linter.Config, 'plugins' | 'rules'> & {
   /**
-   * An object containing a name-value mapping of plugin names to plugin objects. When `files` is specified, these plugins are only available to the matching files.
+   * An object containing a name-value mapping of plugin names to plugin objects.
+   * When `files` is specified, these plugins are only available to the matching files.
    *
    * @see [Using plugins in your configuration](https://eslint.org/docs/latest/user-guide/configuring/configuration-files-new#using-plugins-in-your-configuration)
    */
   plugins?: Record<string, any>
 
   /**
-   * Rules configuration. More flexible to allow plugin rules that may not be perfectly typed.
+   * An object containing the configured rules. When `files` or `ignores` are
+   * specified, these rule configurations are only available to the matching files.
    */
-  rules?: Record<string, Linter.RuleEntry<any> | undefined>
+  rules?: Rules
 }
 
 export interface OptionsFiles {


### PR DESCRIPTION
### Description

This PR updates `TypedFlatConfigItem` to provide rules auto-completion and enhances its JSDoc comments.

During testing, I also discovered a few tiny issues, so this PR updates `constants-generated.ts` and adds the missing `name` property to the Next.js rules configuration.

### Additional context

Rules auto-completion stopped working after the last update due to the type changes introduced in PR #738.

---

Thanks for the great config! ;)