### PR TITLE
fix: broader the dev environment detection

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,6 +138,8 @@ export function isInEditorEnv(): boolean {
   if (isInGitHooksOrLintStaged())
     return false
   return !!(false
+    || process.env.VSCODE_PID
+    || process.env.VSCODE_CWD
     || process.env.TERM_PROGRAM === "vscode"
     || process.env.JETBRAINS_IDE
     || process.env.VIM


### PR DESCRIPTION
### Description

VSCodium does not set `VSCODE_PID` so it was not detected as a dev environment.

The code now checks if there is at least one environment variable starting with "VSCODE_" (there are a few ones on VSCodium)

### Linked Issues

Fixes #747

### Additional context

I was investigating why my editor was falling into this kind of error: "eslint RangeError: Error while loading rule 'prefer-const': Maximum call stack size exceeded".