### PR TITLE
fix: use ecmaVersion 'latest' per eslint's docs recommendation

### DIFF
--- a/src/configs/javascript.ts
+++ b/src/configs/javascript.ts
@@ -15,7 +15,7 @@ export async function javascript(
   return [
     {
       languageOptions: {
-        ecmaVersion: 2022,
+        ecmaVersion: 'latest',
         globals: {
           ...globals.browser,
           ...globals.es2021,
@@ -28,7 +28,7 @@ export async function javascript(
           ecmaFeatures: {
             jsx: true,
           },
-          ecmaVersion: 2022,
+          ecmaVersion: 'latest',
           sourceType: 'module',
         },
         sourceType: 'module',


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
PR switches to `ecmaVersion: 'latest'` per recommendation from eslint documentation https://eslint.org/docs/latest/use/configure/language-options#specifying-javascript-options. 

> In most cases, we recommend using the default of "latest" to ensure you’re always using the most recent ECMAScript version.

For example current value of `ecmaVersion: 2022` doesn't support [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with) which prevents eslint from parsing file when such import is encountered. This can be demonstrated in [eslint's playground](https://eslint.org/play/#eyJ0ZXh0IjoiaW1wb3J0IGpzb24gZnJvbSBcIi4vZm9vLmpzb25cIiB3aXRoIHsgdHlwZTogXCJqc29uXCIgfTtcbmltcG9ydChcImZvby5qc29uXCIsIHsgd2l0aDogeyB0eXBlOiBcImpzb25cIiB9IH0pO1xuXG52YXIgYSA9IDE7Iiwib3B0aW9ucyI6eyJydWxlcyI6eyJuby12YXIiOlsiZXJyb3IiXX0sImxhbmd1YWdlT3B0aW9ucyI6eyJzb3VyY2VUeXBlIjoibW9kdWxlIiwicGFyc2VyT3B0aW9ucyI6eyJlY21hRmVhdHVyZXMiOnt9fSwiZWNtYVZlcnNpb24iOjIwMjJ9fX0=). Playground shows `Parsing error: Unexpected token with` when `Unexpected var, use let or const instead` should be displayed instead.

Few notes:
1. First I thought about using a fixed `2025` or even `2026` version but I guess we'll be still chasing similar issues each time new syntax gets added. With `latest` config stays in sync with what version of parser eslint ships. 
2. Even though `latest` is default when config is omitted still thought it would be clearer to set it explicitly to `latest`.

### Linked Issues
Discord conversation: https://discord.com/channels/937808017016119440/937977751472840704/1413393048817373245

### Additional context
Not sure if this is a breaking change? Most likely not.
