### PR TITLE
chore: add support for Next.js 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@eslint-react/eslint-plugin": "^2.0.1",
-    "@next/eslint-plugin-next": "^15.4.0-canary.115",
+    "@next/eslint-plugin-next": "^16.0.0",
     "@prettier/plugin-xml": "^3.4.1",
     "@unocss/eslint-plugin": ">=0.50.0",
     "astro-eslint-parser": "^1.0.2",


### PR DESCRIPTION
### Description

Upgrade to Next.js 16 by bumping the peer dependency @next/eslint-plugin-next from ^15.4.0-canary.115 to ^16.0.0. No code changes—just aligning linting/tooling with Next 16.

### Linked Issues

N/A

### Additional context

Verified linting locally; CI should confirm compatibility with the new plugin version.
