### PR TITLE
fix: ts error from commit cb29b1a

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -82,7 +82,7 @@ export const defaultPluginRenaming = {
  *  The merged ESLint configurations.
  */
 export function antfu(
-  options: OptionsConfig & Omit<TypedFlatConfigItem, 'files'> = {},
+  options: OptionsConfig & Omit<TypedFlatConfigItem, 'files' | 'ignores'> = {},
   ...userConfigs: Awaitable<TypedFlatConfigItem | TypedFlatConfigItem[] | FlatConfigComposer<any, any> | Linter.Config[]>[]
 ): FlatConfigComposer<TypedFlatConfigItem, ConfigNames> {
   const {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
https://github.com/antfu/eslint-config/actions/runs/18960301377/job/54145996887
```
Error: test/jsx-a11y.test.ts(10,33): error TS2345: Argument of type '{ gitignore?: boolean | FlatGitignoreOptions; ignores?: string[] | ((originals: string[]) => string[]); lessOpinionated?: boolean; ... 25 more ...; type?: "app" | "lib"; }' is not assignable to parameter of type 'OptionsConfig & Omit<TypedFlatConfigItem, "files">'.
  Type '{ gitignore?: boolean | FlatGitignoreOptions; ignores?: string[] | ((originals: string[]) => string[]); lessOpinionated?: boolean; ... 25 more ...; type?: "app" | "lib"; }' is not assignable to type 'Omit<TypedFlatConfigItem, "files">'.
    Types of property 'ignores' are incompatible.
      Type 'string[] | ((originals: string[]) => string[]) | undefined' is not assignable to type 'string[] | undefined'.
        Type '(originals: string[]) => string[]' is not assignable to type 'string[]'.
 ELIFECYCLE  Command failed with exit code 2.
```

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
