### PR TITLE
chore: set tsdown `fixedExtension: false` to have .js output instead of .mjs

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   ],
   shims: true,
   format: ['esm'],
+  fixedExtension: false,
 })


### PR DESCRIPTION
Close #786 

### Description

`tsdown` major seems change the output build when platform is `node`


### Linked Issues

https://github.com/rolldown/tsdown/pull/517

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
