### PR TITLE
fix(pnpm): add pnpm options to settings

### DIFF
--- a/src/configs/pnpm.ts
+++ b/src/configs/pnpm.ts
@@ -1,4 +1,4 @@
-import type { OptionsPnpm, TypedFlatConfigItem } from '../types'
+import type { OptionsIsInEditor, OptionsPnpm, TypedFlatConfigItem } from '../types'
 import fs from 'node:fs/promises'
 import { findUp } from 'find-up-simple'
 
@@ -14,7 +14,7 @@ async function detectCatalogUsage(): Promise<boolean> {
 }
 
 export async function pnpm(
-  options: OptionsPnpm,
+  options: OptionsPnpm & OptionsIsInEditor = {},
 ): Promise<TypedFlatConfigItem[]> {
   const [
     pluginPnpm,

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -285,6 +285,7 @@ export function antfu(
   if (enableCatalogs) {
     configs.push(
       pnpm({
+        ...resolveSubOptions(options, 'pnpm'),
         isInEditor,
       }),
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,7 +257,7 @@ export interface OptionsIsInEditor {
   isInEditor?: boolean
 }
 
-export interface OptionsPnpm extends OptionsIsInEditor {
+export interface OptionsPnpm {
   /**
    * Requires catalogs usage
    */
@@ -485,7 +485,7 @@ export interface OptionsConfig extends OptionsComponentExts, OptionsProjectType 
    * @experimental
    * @default false
    */
-  pnpm?: boolean
+  pnpm?: boolean | OptionsPnpm
 
   /**
    * Use external formatters to format files.


### PR DESCRIPTION
### Description

Expose `catalogs` option to users via `pnpm` config.

Previously `pnpm` was boolean-only, so users couldn't explicitly control the `catalogs` rule. Now accepts `{ catalogs: boolean }` to override smart detection.

```ts
// disable catalogs enforcement even in pnpm workspace
export default antfu({
  pnpm: { catalogs: false }
})
```

### Linked Issues

### Additional context

Removed `extends OptionsIsInEditor` from `OptionsPnpm` - no other config allows overriding `isInEditor` per-plugin so move this to the `pnpm` config directly.
