### PR TITLE
fix(pnpm): add ignore for @types/vscode in json-enforce-catalog

### DIFF
--- a/src/configs/pnpm.ts
+++ b/src/configs/pnpm.ts
@@ -57,7 +57,10 @@ export async function pnpm(
             ? {
                 'pnpm/json-enforce-catalog': [
                   'error',
-                  { autofix: !isInEditor },
+                  {
+                    autofix: !isInEditor,
+                    ignores: ['@types/vscode'],
+                  },
                 ],
               }
             : {}),


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

`vsce` does not currently recognize catalog resolution for `@types/vscode`, which causes the packaging step to fail.

### Additional context

This can be reverted once`vsce` adds support for catalog dependencies.
