### PR TITLE
chore(react): move no-implicit-key as typeAwareRule

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prepare": "simple-git-hooks"
   },
   "peerDependencies": {
-    "@eslint-react/eslint-plugin": "^2.0.1",
+    "@eslint-react/eslint-plugin": "^2.11.0",
     "@next/eslint-plugin-next": ">=15.0.0",
     "@prettier/plugin-xml": "^3.4.1",
     "@unocss/eslint-plugin": ">=0.50.0",

--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -54,6 +54,7 @@ export async function react(
 
   const typeAwareRules: TypedFlatConfigItem['rules'] = {
     'react/no-leaked-conditional-rendering': 'warn',
+    'react/no-implicit-key': 'warn',
   }
 
   const [
@@ -121,7 +122,6 @@ export async function react(
         'react/no-direct-mutation-state': 'error',
         'react/no-duplicate-key': 'error',
         'react/no-forward-ref': 'warn',
-        'react/no-implicit-key': 'warn',
         'react/no-missing-key': 'error',
         'react/no-nested-component-definitions': 'error',
         'react/no-nested-lazy-component-declarations': 'error',

--- a/test/__snapshots__/factory/full-on.snap.js
+++ b/test/__snapshots__/factory/full-on.snap.js
@@ -899,7 +899,6 @@
       "react/no-direct-mutation-state",
       "react/no-duplicate-key",
       "react/no-forward-ref",
-      "react/no-implicit-key",
       "react/no-missing-key",
       "react/no-nested-component-definitions",
       "react/no-nested-lazy-component-declarations",
@@ -966,6 +965,7 @@
     "name": "antfu/react/type-aware-rules",
     "rules": [
       "react/no-leaked-conditional-rendering",
+      "react/no-implicit-key",
     ],
   },
   {


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

With the release of the v2.10.0 of `@eslint-react/eslint-plugin` the rule `react/no-implicit-key` is now a "strict-type-checked" rule (cf. https://github.com/Rel1cx/eslint-react/releases/tag/v2.10.0 or https://www.eslint-react.xyz/docs/rules/no-implicit-key).

I move the rule inside the `typeAwareRules` vars in the react config file.

Without this change this kind of error will appear:
```
Error: Error while loading rule 'react/no-implicit-key': You have used a rule which requires type information, but don't have parserOptions set to generate type information for this file. See https://tseslint.com/typed-linting for enabling linting with type information.
Parser: (unknown)
Note: detected a parser other than @typescript-eslint/parser. Make sure the parser is configured to forward "parserOptions.project" to @typescript-eslint/parser.
Occurred while linting /Users/xxx/xxx/xxx/eslint.config.mjs
```


### Additional context

Since I don't use pnpm, I don't update any pnpm file (workspace or lock file).
I'm also no familiar with the testing process, but I still update the `full-on.snap.js`.

Moreover, the latest release is the v2.11.0` that I chnage on the devDeps in pkg.json, but this minimal version requirement should be updated more globally, but this PR seems at least revelant to start a fix about this change whit the react plugin.

I will stay available if I can help anything about this point.