### PR TITLE
feat(stylistic): Allow easy setting brace style

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ export default antfu({
   stylistic: {
     indent: 2, // 4, or 'tab'
     quotes: 'single', // or 'double'
+    braceStyle: 'stroustrup', // '1tbs', or 'allman'
   },
 
   // TypeScript and Vue are autodetected, you can also explicitly enable them:

--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -35,6 +35,7 @@ export async function stylistic(
   const pluginStylistic = await interopDefault(import('@stylistic/eslint-plugin'))
 
   const config = pluginStylistic.configs.customize({
+    braceStyle,
     experimental,
     indent,
     jsx,
@@ -72,7 +73,6 @@ export async function stylistic(
             }
         ),
 
-        'style/brace-style': ['error', braceStyle, { allowSingleLine: false }],
         'style/generator-star-spacing': ['error', { after: true, before: false }],
         'style/yield-star-spacing': ['error', { after: true, before: false }],
 

--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -3,6 +3,7 @@ import { pluginAntfu } from '../plugins'
 import { interopDefault } from '../utils'
 
 export const StylisticConfigDefaults: StylisticConfig = {
+  braceStyle: 'stroustrup',
   experimental: false,
   indent: 2,
   jsx: true,
@@ -18,6 +19,7 @@ export async function stylistic(
   options: StylisticOptions = {},
 ): Promise<TypedFlatConfigItem[]> {
   const {
+    braceStyle,
     experimental,
     indent,
     jsx,
@@ -70,6 +72,7 @@ export async function stylistic(
             }
         ),
 
+        'style/brace-style': ['error', braceStyle, { allowSingleLine: false }],
         'style/generator-star-spacing': ['error', { after: true, before: false }],
         'style/yield-star-spacing': ['error', { after: true, before: false }],
 

--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -183,7 +183,7 @@ export async function vue(
                 multiline: 'always',
                 singleline: 'always',
               }],
-              'vue/brace-style': ['error', braceStyle, { allowSingleLine: false }],
+              'vue/brace-style': ['error', braceStyle, { allowSingleLine: true }],
               'vue/comma-dangle': ['error', 'always-multiline'],
               'vue/comma-spacing': ['error', { after: true, before: false }],
               'vue/comma-style': ['error', 'last'],

--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -27,6 +27,7 @@ export async function vue(
     : options.sfcBlocks ?? {}
 
   const {
+    braceStyle = 'stroustrup',
     indent = 2,
   } = typeof stylistic === 'boolean' ? {} : stylistic
 
@@ -182,7 +183,7 @@ export async function vue(
                 multiline: 'always',
                 singleline: 'always',
               }],
-              'vue/brace-style': ['error', 'stroustrup', { allowSingleLine: true }],
+              'vue/brace-style': ['error', braceStyle, { allowSingleLine: false }],
               'vue/comma-dangle': ['error', 'always-multiline'],
               'vue/comma-spacing': ['error', { after: true, before: false }],
               'vue/comma-style': ['error', 'last'],

--- a/src/types.ts
+++ b/src/types.ts
@@ -259,7 +259,7 @@ export interface OptionsStylistic {
 }
 
 export interface StylisticConfig
-  extends Pick<StylisticCustomizeOptions, 'indent' | 'quotes' | 'jsx' | 'semi' | 'experimental'> {
+  extends Pick<StylisticCustomizeOptions, 'indent' | 'quotes' | 'jsx' | 'semi' | 'braceStyle' | 'experimental'> {
 }
 
 export interface OptionsOverrides {

--- a/test/__snapshots__/api/index.snapshot.d.ts
+++ b/test/__snapshots__/api/index.snapshot.d.ts
@@ -1964,7 +1964,7 @@ export interface RuleOptions {
   'yield-star-spacing'?: Linter.RuleEntry<YieldStarSpacing>;
   'yoda'?: Linter.RuleEntry<Yoda>;
 }
-export interface StylisticConfig extends Pick<StylisticCustomizeOptions, 'indent' | 'quotes' | 'jsx' | 'semi' | 'experimental'> {}
+export interface StylisticConfig extends Pick<StylisticCustomizeOptions, 'indent' | 'quotes' | 'jsx' | 'semi' | 'braceStyle' | 'experimental'> {}
 export interface StylisticOptions extends StylisticConfig, OptionsOverrides {
   lessOpinionated?: boolean;
 }


### PR DESCRIPTION
### 🧭 Context

As one of the most controversial code style, I believe it is good for users to easily select the refered brace style.

### 📚 Description

This PR unlock the availability of setting `brace-style` inside `antfu()` factory below `stylistic` key:
```ts
export default antfu({
  stylistic: {
    braceStyle: 'stroustrup', // '1tbs', or 'allman'
  }
})
```
However, to keep the setting clean and simple, it changes the style only.
People who want to set `allowSingleLine: false` will still need to write a override themselves.
