### PR TITLE
fix(deps): accept `eslint-plugin-astro` v2 to resolve unmet peer warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@unocss/eslint-plugin": ">=0.50.0",
     "astro-eslint-parser": "^1.0.2",
     "eslint": "^9.10.0 || ^10.0.0",
-    "eslint-plugin-astro": "^1.2.0",
+    "eslint-plugin-astro": ">=1.2.0",
     "eslint-plugin-format": ">=0.1.0",
     "eslint-plugin-jsx-a11y": ">=6.10.2",
     "eslint-plugin-react-refresh": "^0.5.0",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- If there is an existing issue, replace the line below with e.g. "resolves #123" -->

No linked issue, but have linked commit: https://github.com/antfu/eslint-config/commit/82078763e3125e37eb673973eff2af3d4baa6c14

### 🧭 Context

The `eslint-plugin-astro` devDependency was bumped to v2 (resolved through `catalog:peer`) in the `@antfu/eslint-config` v9.1.0, but the `peerDependencies` constraint was left pinned at `^1.2.0`. Because `^1.2.0` does not allow v2, package managers report an unmet peer dependency for anyone installing `eslint-plugin-astro` v2. This will confuse Astro users.

If I installed `eslint-plugin-astro` v2 with pnpm and then checked the peer version:

```
$ pnpm peers check
Issues with peer dependencies found

✕ unmet peer eslint-plugin-astro
  Installed: 2.1.1
  Wanted:
    ^1.2.0:
      @antfu/eslint-config@9.1.0
```

Consumers currently have to ignore this warning with a manual override (e.g. `overrides: { eslint-plugin-astro: 2.1.1 }`), which is not ideal.

### 📚 Description

This PR relaxes the `eslint-plugin-astro` peer range from `^1.2.0` to `>=1.2.0`, so both v1 and v2 are accepted. This matches the actual devDependency (v2) and aligns with how other peers in this config are declared with `>=` (e.g. `eslint-plugin-jsx-a11y`, `eslint-plugin-format`).

The change is limited to the `peerDependencies` field in `package.json`; no runtime logic or config behavior is affected, so no new tests are needed.